### PR TITLE
Process rave metadata key for package metadata overrides.

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -100,7 +100,7 @@ function gatherExtensions (context) {
 					? pkg.metadata.rave
 					: pkg.metadata.rave.extension;
 
-				if(moduleName) {
+				if (moduleName) {
 					promises.push(initExtension(context, pkg.name, pkg.metadata.rave));
 				}
 
@@ -113,7 +113,7 @@ function gatherExtensions (context) {
 function applyRavePackageMetadata(context) {
 	var rave = context.app.metadata.metadata.rave;
 
-	if(rave && rave.overrides) {
+	if (rave && rave.overrides) {
 		applyOverrides(context.packages, rave.overrides);
 	}
 
@@ -122,11 +122,11 @@ function applyRavePackageMetadata(context) {
 
 function applyOverrides(packages, overrides) {
 	var name, pkg, key, pkgOverrides;
-	for(name in overrides) {
+	for (name in overrides) {
 		pkg = packages[name];
-		if(pkg) {
+		if (pkg) {
 			pkgOverrides = overrides[name];
-			for(key in pkgOverrides) {
+			for (key in pkgOverrides) {
 				pkg[key] = pkgOverrides[key];
 			}
 		}

--- a/auto.js
+++ b/auto.js
@@ -110,7 +110,7 @@ function gatherExtensions (context) {
 	return Promise.all(promises);
 }
 
-function applyRavePackageMetadata(context) {
+function applyRavePackageMetadata (context) {
 	var rave = context.app.metadata.metadata.rave;
 
 	if (rave && rave.overrides) {
@@ -120,7 +120,7 @@ function applyRavePackageMetadata(context) {
 	return context;
 }
 
-function applyOverrides(packages, overrides) {
+function applyOverrides (packages, overrides) {
 	var name, pkg, key, pkgOverrides;
 	for (name in overrides) {
 		pkg = packages[name];


### PR DESCRIPTION
This change allows the rave metadata prop to be an object or string,
opening up future expansion for extensions.  More immediately, though,
it lets the app metadata provide a rave object prop containing
overrides for package metadata.  Essential for bower packages that
don't yet specify moduleType. Keys in the overrides forcibly overwrite
existing keys.
