### PR TITLE
Make metadata crawling add main module path as module location

### DIFF
--- a/lib/createVersionedIdTransform.js
+++ b/lib/createVersionedIdTransform.js
@@ -1,6 +1,7 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
+var createUid = require('./uid').create;
 var metadata = require('./metadata');
 var path = require('./path');
 
@@ -34,7 +35,7 @@ function createVersionedIdTransform (context) {
 
 		if (normalized.indexOf('#') < 0) {
 			// it's not already an uid
-			normalized = metadata.createUid(depPkg, normalized);
+			normalized = createUid(depPkg, normalized);
 		}
 
 		return normalized;

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -16,9 +16,7 @@ var metaNameToCrawler = {
 module.exports = {
 	crawl: crawlStart,
 	findPackage: findPackageDescriptor,
-	findDepPackage: findDependentPackage,
-	createUid: createUid,
-	parseUid: parseUid
+	findDepPackage: findDependentPackage
 };
 
 function crawlStart (context, rootUrl) {
@@ -59,23 +57,5 @@ function findDependentPackage (descriptors, fromPkg, depName) {
 		// get dep pkg uid
 		depPkgUid = fromPkg ? fromPkg.deps[pkgName] : pkgName;
 		return depPkgUid && descriptors[depPkgUid];
-	}
-}
-
-function createUid (descriptor, normalized) {
-	return /*descriptor.metaType + ':' +*/ descriptor.name
-		+ (descriptor.version ? '@' + descriptor.version : '')
-		+ (normalized ? '#' + normalized : '');
-}
-
-function parseUid (uid) {
-	var uparts = uid.split('#');
-	var name = uparts.pop();
-	var nparts = name.split('/');
-	return {
-		name: name,
-		pkgName: nparts.shift(),
-		modulePath: nparts.join('/'),
-		pkgUid: uparts[0]
 	}
 }

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -1,6 +1,7 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
+var parseUid = require('./uid').parse;
 var path = require('./path');
 var beget = require('./beget');
 
@@ -27,8 +28,6 @@ function crawlStart (context, rootUrl) {
 	crawler = metaNameToCrawler[metaName];
 
 	if (!crawler) throw new Error('Unknown metadata file: ' + rootUrl);
-
-	crawler.createUid = createUid;
 
 	return crawl.start(context, crawler, rootUrl);
 }

--- a/lib/metadata/base.js
+++ b/lib/metadata/base.js
@@ -1,6 +1,7 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
+var createUid = require('../uid').create;
 var path = require('../path');
 
 module.exports = {
@@ -16,8 +17,6 @@ module.exports = {
 	pkgName: null,
 
 	pkgRoot: null,
-
-	createUid: null,
 
 	setRootUrl: function (url) {
 		this.pkgRoot = path.splitDirAndFile(url)[0];
@@ -45,7 +44,7 @@ module.exports = {
 			main: metadata.main,
 			metadata: metadata
 		};
-		descr.uid = this.createUid(descr);
+		descr.uid = createUid(descr);
 		return descr;
 	}
 

--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -28,13 +28,21 @@ bowerCrawler.fetchAltMetaFile = function () {
 };
 
 bowerCrawler.createDescriptor = function (metadata) {
-	var descr;
+	var descr, mainPath;
 	descr = base.createDescriptor.call(this, metadata);
 	descr.metaType = 'bower';
 	descr.moduleType = this.findModuleType(metadata);
 	descr.main = metadata.main && this.findJsMain(metadata.main);
-	if (descr.main && !this.isGlobalScript(descr)) {
-		descr.main = path.removeExt(descr.main);
+	if(descr.main) {
+		if (!this.isGlobalScript(descr)) {
+			descr.main = path.removeExt(descr.main);
+		}
+
+		mainPath = path.splitDirAndFile(descr.main);
+		if (mainPath[0]) {
+			descr.location = path.joinPaths(descr.location, mainPath[0]);
+			descr.main = mainPath[1];
+		}
 	}
 	return descr;
 };

--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -33,7 +33,7 @@ bowerCrawler.createDescriptor = function (metadata) {
 	descr.metaType = 'bower';
 	descr.moduleType = this.findModuleType(metadata);
 	descr.main = metadata.main && this.findJsMain(metadata.main);
-	if(descr.main) {
+	if (descr.main) {
 		if (!this.isGlobalScript(descr)) {
 			descr.main = path.removeExt(descr.main);
 		}

--- a/lib/metadata/npm.js
+++ b/lib/metadata/npm.js
@@ -19,9 +19,17 @@ npmCrawler.setPackage = function (name) {
 };
 
 npmCrawler.createDescriptor =  function (metadata) {
-	var descr = base.createDescriptor.call(this, metadata);
+	var descr, mainPath;
+	descr = base.createDescriptor.call(this, metadata);
 	descr.metaType = 'npm';
 	descr.moduleType = metadata.moduleType || ['node'];
-	if (metadata.main) descr.main = path.removeExt(metadata.main);
+	if (metadata.main) {
+		descr.main = path.removeExt(metadata.main);
+		mainPath = path.splitDirAndFile(descr.main);
+		if (mainPath[0]) {
+			descr.location = path.joinPaths(descr.location, mainPath[0]);
+			descr.main = mainPath[1];
+		}
+	}
 	return descr;
 };

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,6 +1,7 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
+var parseUid = require('./uid').parse;
 var metadata = require('./metadata');
 var normalizeCjs = require('../pipeline/normalizeCjs');
 var createNormalizer = require('./createNormalizer');
@@ -44,7 +45,7 @@ function createIsConfigured (context) {
 			// arg is an abstract (non-unique) name
 			if (arg.charAt(0) === '.') {
 				// arg is relative, use the referer's name
-				pkgUid = metadata.parseUid(arguments[1]).pkgUid;
+				pkgUid = parseUid(arguments[1]).pkgUid;
 			}
 			else {
 				pkgUid = arg.split('/')[0];
@@ -52,7 +53,7 @@ function createIsConfigured (context) {
 		}
 		else {
 			// arg is a load context with an uid
-			pkgUid = metadata.parseUid(arg.name).pkgUid;
+			pkgUid = parseUid(arg.name).pkgUid;
 		}
 		return pkgUid in packages;
 	};

--- a/lib/uid.js
+++ b/lib/uid.js
@@ -1,0 +1,20 @@
+exports.create = createUid;
+exports.parse = parseUid;
+
+function createUid (descriptor, normalized) {
+	return /*descriptor.metaType + ':' +*/ descriptor.name
+		+ (descriptor.version ? '@' + descriptor.version : '')
+		+ (normalized ? '#' + normalized : '');
+}
+
+function parseUid (uid) {
+	var uparts = uid.split('#');
+	var name = uparts.pop();
+	var nparts = name.split('/');
+	return {
+		name: name,
+		pkgName: nparts.shift(),
+		modulePath: nparts.join('/'),
+		pkgUid: uparts[0]
+	}
+}

--- a/pipeline/locatePackage.js
+++ b/pipeline/locatePackage.js
@@ -4,6 +4,7 @@
 module.exports = locatePackage;
 
 var path = require('../lib/path');
+var parseUid = require('../lib/uid').parse;
 var metadata = require('../lib/metadata');
 
 function locatePackage (load) {
@@ -14,7 +15,7 @@ function locatePackage (load) {
 
 	if (!options.packages) throw new Error('Packages not provided: ' + load.name);
 
-	parts = metadata.parseUid(load.name);
+	parts = parseUid(load.name);
 	packageName = parts.pkgUid || parts.pkgName;
 	modulePath = parts.modulePath;
 

--- a/test/lib/metadata/bower.js
+++ b/test/lib/metadata/bower.js
@@ -1,0 +1,54 @@
+var buster = require('buster');
+var assert = buster.assert;
+var refute = buster.refute;
+
+var bower = require('../../../lib/metadata/bower');
+
+buster.testCase('lib/metadata/bower', {
+
+	createDescriptor: {
+		'should append main dirname to location': function() {
+			var bowerTest = Object.create(bower, {
+				pkgRoot: { value: 'existing/part' }
+			});
+
+			var dsc = bowerTest.createDescriptor({
+				main: 'deep/path/to/main.js'
+			});
+
+			assert.equals(dsc.location, 'existing/part/deep/path/to');
+		},
+
+		'should set main to main basename': function() {
+			var dsc = bower.createDescriptor({
+				main: 'deep/path/to/main.js'
+			});
+
+			assert.equals(dsc.main, 'main.js');
+		},
+
+		'should remove main extension if moduleType !== globals': function() {
+			var dsc = bower.createDescriptor({
+				main: 'deep/path/to/main.js',
+				moduleType: ['amd']
+			});
+
+			assert.equals(dsc.main, 'main');
+		},
+
+		'should use moduleType if specified': function() {
+			var dsc = bower.createDescriptor({
+				moduleType: ['a', 'b']
+			});
+
+			assert.equals(dsc.moduleType, ['a', 'b']);
+		},
+
+		'should default moduleType to ["globals"] if not specified': function() {
+			var dsc = bower.createDescriptor({});
+
+			assert.equals(dsc.moduleType, ['globals']);
+		}
+	}
+
+});

--- a/test/lib/metadata/npm.js
+++ b/test/lib/metadata/npm.js
@@ -1,0 +1,45 @@
+var buster = require('buster');
+var assert = buster.assert;
+var refute = buster.refute;
+
+var npm = require('../../../lib/metadata/npm');
+
+buster.testCase('lib/metadata/npm', {
+
+	createDescriptor: {
+		'should append main dirname to location': function() {
+			var npmTest = Object.create(npm, {
+				pkgRoot: { value: 'existing/part' }
+			});
+
+			var dsc = npmTest.createDescriptor({
+				main: 'deep/path/to/main.js'
+			});
+
+			assert.equals(dsc.location, 'existing/part/deep/path/to');
+		},
+
+		'should set main to main basename and remove file extension': function() {
+			var dsc = npm.createDescriptor({
+				main: 'deep/path/to/main.js'
+			});
+
+			assert.equals(dsc.main, 'main');
+		},
+
+		'should use moduleType if specified': function() {
+			var dsc = npm.createDescriptor({
+				moduleType: ['a', 'b']
+			});
+
+			assert.equals(dsc.moduleType, ['a', 'b']);
+		},
+
+		'should default moduleType to ["node"] if not specified': function() {
+			var dsc = npm.createDescriptor({});
+
+			assert.equals(dsc.moduleType, ['node']);
+		}
+	}
+
+});

--- a/test/lib/uid.js
+++ b/test/lib/uid.js
@@ -1,0 +1,50 @@
+var buster = require('buster');
+var assert = buster.assert;
+var refute = buster.refute;
+
+var uid = require('../../lib/uid');
+
+// TODO: Make these tests better
+buster.testCase('lib/uid', {
+
+	create: {
+		'when normalized is not provided': {
+			'should create name@version from descriptor with name and version': function() {
+				var u = uid.create({ name: 'a', version: '1' });
+				assert.equals(u, 'a@1');
+			},
+
+			'should create name from descriptor with only name': function() {
+				var u = uid.create({ name: 'a' });
+				assert.equals(u, 'a');
+			}
+		},
+
+		'when normalized is provided': {
+			'should create name@version#normalized from descriptor with name and version': function() {
+				var u = uid.create({ name: 'a', version: '1' }, 'b');
+				assert.equals(u, 'a@1#b');
+
+			},
+
+			'should create name#normalized from descriptor with only name': function() {
+				var u = uid.create({ name: 'a' }, 'b');
+				assert.equals(u, 'a#b');
+			}
+
+		}
+
+	},
+
+	// TODO: More/better tests for parse
+	parse: {
+		'should have name, pkgName, modulePath, and pkgUid': function() {
+			var parsed = uid.parse('a#b/c/d');
+			assert.equals(parsed.name, 'b/c/d');
+			assert.equals(parsed.pkgName, 'b');
+			assert.equals(parsed.modulePath, 'c/d');
+			assert.equals(parsed.pkgUid, 'a');
+		}
+	}
+
+});


### PR DESCRIPTION
metadata/bower and npm now parse the path off of the main module
if present, and append it to the package location so that modules
can be found in nested dirs.  Split out uid-related functions, and
added minimal unit tests for uid, bower, and npm bits.

Closes #3
