### PR TITLE
Set npm and bower package location to the root of the package

### DIFF
--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -37,12 +37,6 @@ bowerCrawler.createDescriptor = function (metadata) {
 		if (!this.isGlobalScript(descr)) {
 			descr.main = path.removeExt(descr.main);
 		}
-
-		mainPath = path.splitDirAndFile(descr.main);
-		if (mainPath[0]) {
-			descr.location = path.joinPaths(descr.location, mainPath[0]);
-			descr.main = mainPath[1];
-		}
 	}
 	return descr;
 };

--- a/lib/metadata/npm.js
+++ b/lib/metadata/npm.js
@@ -19,17 +19,12 @@ npmCrawler.setPackage = function (name) {
 };
 
 npmCrawler.createDescriptor =  function (metadata) {
-	var descr, mainPath;
+	var descr;
 	descr = base.createDescriptor.call(this, metadata);
 	descr.metaType = 'npm';
 	descr.moduleType = metadata.moduleType || ['node'];
 	if (metadata.main) {
 		descr.main = path.removeExt(metadata.main);
-		mainPath = path.splitDirAndFile(descr.main);
-		if (mainPath[0]) {
-			descr.location = path.joinPaths(descr.location, mainPath[0]);
-			descr.main = mainPath[1];
-		}
 	}
 	return descr;
 };

--- a/test/lib/metadata/bower.js
+++ b/test/lib/metadata/bower.js
@@ -7,7 +7,7 @@ var bower = require('../../../lib/metadata/bower');
 buster.testCase('lib/metadata/bower', {
 
 	createDescriptor: {
-		'should append main dirname to location': function() {
+		'should not append main dirname to location': function() {
 			var bowerTest = Object.create(bower, {
 				pkgRoot: { value: 'existing/part' }
 			});
@@ -16,7 +16,7 @@ buster.testCase('lib/metadata/bower', {
 				main: 'deep/path/to/main.js'
 			});
 
-			assert.equals(dsc.location, 'existing/part/deep/path/to');
+			assert.equals(dsc.location, 'existing/part');
 		},
 
 		'should set main to main basename': function() {
@@ -24,7 +24,7 @@ buster.testCase('lib/metadata/bower', {
 				main: 'deep/path/to/main.js'
 			});
 
-			assert.equals(dsc.main, 'main.js');
+			assert.equals(dsc.main, 'deep/path/to/main.js');
 		},
 
 		'should remove main extension if moduleType !== globals': function() {
@@ -33,7 +33,7 @@ buster.testCase('lib/metadata/bower', {
 				moduleType: ['amd']
 			});
 
-			assert.equals(dsc.main, 'main');
+			assert.equals(dsc.main, 'deep/path/to/main');
 		},
 
 		'should use moduleType if specified': function() {

--- a/test/lib/metadata/npm.js
+++ b/test/lib/metadata/npm.js
@@ -7,7 +7,7 @@ var npm = require('../../../lib/metadata/npm');
 buster.testCase('lib/metadata/npm', {
 
 	createDescriptor: {
-		'should append main dirname to location': function() {
+		'should not append main dirname to location': function() {
 			var npmTest = Object.create(npm, {
 				pkgRoot: { value: 'existing/part' }
 			});
@@ -16,15 +16,15 @@ buster.testCase('lib/metadata/npm', {
 				main: 'deep/path/to/main.js'
 			});
 
-			assert.equals(dsc.location, 'existing/part/deep/path/to');
+			assert.equals(dsc.location, 'existing/part');
 		},
 
-		'should set main to main basename and remove file extension': function() {
+		'should remove file extension': function() {
 			var dsc = npm.createDescriptor({
 				main: 'deep/path/to/main.js'
 			});
 
-			assert.equals(dsc.main, 'main');
+			assert.equals(dsc.main, 'deep/path/to/main');
 		},
 
 		'should use moduleType if specified': function() {


### PR DESCRIPTION
Fixes #24

This preserves the node behaviour, where relative requires
within nested main work as expected. E.g. a package with

"name": "mypkg",
"main": "./lib/index"

can use files from the package root in the main file like so

require("../foo/bar")

Other packages can read files from anywhere in the package
regardless of whether the main is nested, e.g.

require("mypkg/foo/bar")
