### PR TITLE
Add support for browser field in package.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Tab indentation (no size specified)
+[*.js]
+indent_style = tab

--- a/lib/blank.js
+++ b/lib/blank.js
@@ -1,0 +1,7 @@
+/** @license MIT License (c) copyright 2014 original authors */
+
+/**
+ * This module is used when a module in a map is set to false.
+ * Setting module to false in a map (e.g. `browser` field in npm's package.json),
+ * means that module should not be loaded, so instead we load an blank module.
+ */

--- a/lib/blank.js
+++ b/lib/blank.js
@@ -1,4 +1,5 @@
 /** @license MIT License (c) copyright 2014 original authors */
+/** @author Karolis Narkevicius */
 
 /**
  * This module is used when a module in a map is set to false.

--- a/lib/createMapper.js
+++ b/lib/createMapper.js
@@ -10,14 +10,14 @@ function createMapper (context) {
 
 	packages = context.packages;
 
-	return function (normalized, refUid) {
+	return function (normalizedModuleName, refUid) {
 		var refPkg, mappedId;
 
 		refPkg = metadata.findPackage(packages, refUid);
 
 		if (refPkg.map) {
 			for (mappedId in refPkg.map) {
-				if (mappedId === normalized) {
+				if (mappedId === normalizedModuleName) {
 					return refPkg.map[mappedId]
 						? refPkg.map[mappedId]
 						: 'rave/lib/blank';
@@ -25,6 +25,6 @@ function createMapper (context) {
 			}
 		}
 
-		return normalized;
+		return normalizedModuleName;
 	};
 }

--- a/lib/createMapper.js
+++ b/lib/createMapper.js
@@ -1,0 +1,28 @@
+/** @license MIT License (c) copyright 2014 original authors */
+var createUid = require('./uid').create;
+var metadata = require('./metadata');
+var path = require('./path');
+
+module.exports = createMapper;
+
+function createMapper (context, normalize) {
+	var packages;
+
+	packages = context.packages;
+
+	return function (normalized, refUid, refUrl) {
+		var refPkg, mappedId;
+
+		refPkg = metadata.findPackage(packages, refUid);
+
+		if (refPkg.map) {
+			for (mappedId in refPkg.map) {
+				if (normalize(mappedId, refUid, refUrl) === normalized) {
+					return normalize(refPkg.map[mappedId], refUid, refUrl);
+				}
+			}
+		}
+
+		return normalized;
+	};
+}

--- a/lib/createMapper.js
+++ b/lib/createMapper.js
@@ -18,7 +18,9 @@ function createMapper (context, normalize) {
 		if (refPkg.map) {
 			for (mappedId in refPkg.map) {
 				if (normalize(mappedId, refUid, refUrl) === normalized) {
-					return normalize(refPkg.map[mappedId], refUid, refUrl);
+					return refPkg.map[mappedId]
+						? normalize(refPkg.map[mappedId], refUid, refUrl)
+						: 'rave/lib/blank';
 				}
 			}
 		}

--- a/lib/createMapper.js
+++ b/lib/createMapper.js
@@ -1,4 +1,5 @@
 /** @license MIT License (c) copyright 2014 original authors */
+/** @author Karolis Narkevicius */
 var createUid = require('./uid').create;
 var metadata = require('./metadata');
 var path = require('./path');

--- a/lib/createMapper.js
+++ b/lib/createMapper.js
@@ -10,14 +10,14 @@ function createMapper (context) {
 
 	packages = context.packages;
 
-	return function (normalizedModuleName, refUid) {
+	return function (normalizedName, refUid) {
 		var refPkg, mappedId;
 
 		refPkg = metadata.findPackage(packages, refUid);
 
 		if (refPkg.map) {
 			for (mappedId in refPkg.map) {
-				if (mappedId === normalizedModuleName) {
+				if (mappedId === normalizedName) {
 					return refPkg.map[mappedId]
 						? refPkg.map[mappedId]
 						: 'rave/lib/blank';
@@ -25,6 +25,6 @@ function createMapper (context) {
 			}
 		}
 
-		return normalizedModuleName;
+		return normalizedName;
 	};
 }

--- a/lib/createMapper.js
+++ b/lib/createMapper.js
@@ -1,26 +1,25 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Karolis Narkevicius */
-var createUid = require('./uid').create;
 var metadata = require('./metadata');
 var path = require('./path');
 
 module.exports = createMapper;
 
-function createMapper (context, normalize) {
+function createMapper (context) {
 	var packages;
 
 	packages = context.packages;
 
-	return function (normalized, refUid, refUrl) {
+	return function (normalized, refUid) {
 		var refPkg, mappedId;
 
 		refPkg = metadata.findPackage(packages, refUid);
 
 		if (refPkg.map) {
 			for (mappedId in refPkg.map) {
-				if (normalize(mappedId, refUid, refUrl) === normalized) {
+				if (mappedId === normalized) {
 					return refPkg.map[mappedId]
-						? normalize(refPkg.map[mappedId], refUid, refUrl)
+						? refPkg.map[mappedId]
 						: 'rave/lib/blank';
 				}
 			}

--- a/lib/createNormalizer.js
+++ b/lib/createNormalizer.js
@@ -3,9 +3,10 @@
 /** @author John Hann */
 module.exports = createNormalizer;
 
-function createNormalizer (idTransform, normalize) {
+function createNormalizer (idTransform, map, normalize) {
 	return function (name, refererName, refererUrl) {
 		var normalized = normalize(name, refererName, refererUrl);
-		return idTransform(normalized, refererName, refererUrl);
+		var mapped = map(normalized, refererName, refererUrl);
+		return idTransform(mapped, refererName, refererUrl);
 	};
 }

--- a/lib/createNormalizer.js
+++ b/lib/createNormalizer.js
@@ -6,12 +6,6 @@ module.exports = createNormalizer;
 function createNormalizer (idTransform, map, normalize) {
 	return function (name, refererName, refererUrl) {
 		var normalized = normalize(name, refererName, refererUrl);
-		// after we normalize the module id, remove the uid bit and only keep
-		// the path, since the map function expects module ids without the uid bit
-		// idTransform will convert the module id back to UID
-		if (normalized.indexOf('#') > -1) {
-			normalized = normalized.split("#")[1];
-		}
 		return idTransform(map(normalized, refererName), refererName, refererUrl);
 	};
 }

--- a/lib/createNormalizer.js
+++ b/lib/createNormalizer.js
@@ -6,6 +6,12 @@ module.exports = createNormalizer;
 function createNormalizer (idTransform, map, normalize) {
 	return function (name, refererName, refererUrl) {
 		var normalized = normalize(name, refererName, refererUrl);
+		// after we normalize the module id, remove the uid bit and only keep
+		// the path, since the map function expects module ids without the uid bit
+		// idTransform will convert the module id back to UID
+		if (normalized.indexOf('#') > -1) {
+			normalized = normalized.split("#")[1];
+		}
 		return idTransform(map(normalized, refererName), refererName, refererUrl);
 	};
 }

--- a/lib/createNormalizer.js
+++ b/lib/createNormalizer.js
@@ -6,7 +6,6 @@ module.exports = createNormalizer;
 function createNormalizer (idTransform, map, normalize) {
 	return function (name, refererName, refererUrl) {
 		var normalized = normalize(name, refererName, refererUrl);
-		var mapped = map(normalized, refererName, refererUrl);
-		return idTransform(mapped, refererName, refererUrl);
+		return idTransform(map(normalized, refererName), refererName, refererUrl);
 	};
 }

--- a/lib/createPackageMapper.js
+++ b/lib/createPackageMapper.js
@@ -1,0 +1,14 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Karolis Narkevicius */
+var createMapper = require('./createMapper');
+var getModuleName = require('./uid').getModuleName;
+
+module.exports = createPackageMapper;
+
+function createPackageMapper (context) {
+	var mapper = createMapper(context);
+	return function (uid, refUid, refUrl) {
+		var moduleName = uid.indexOf("#") > -1 ? getModuleName(uid) : uid;
+		return mapper(moduleName, refUid, refUrl);
+	};
+}

--- a/lib/createPackageMapper.js
+++ b/lib/createPackageMapper.js
@@ -1,14 +1,13 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Karolis Narkevicius */
 var createMapper = require('./createMapper');
-var getModuleName = require('./uid').getModuleName;
+var uid = require('./uid');
 
 module.exports = createPackageMapper;
 
 function createPackageMapper (context) {
 	var mapper = createMapper(context);
-	return function (uid, refUid, refUrl) {
-		var moduleName = uid.indexOf("#") > -1 ? getModuleName(uid) : uid;
-		return mapper(moduleName, refUid, refUrl);
+	return function (normalizedName, refUid, refUrl) {
+		return mapper(uid.getName(normalizedName), refUid, refUrl);
 	};
 }

--- a/lib/hooksFromMetadata.js
+++ b/lib/hooksFromMetadata.js
@@ -6,6 +6,7 @@ var metadata = require('./metadata');
 var normalizeCjs = require('../pipeline/normalizeCjs');
 var createNormalizer = require('./createNormalizer');
 var createVersionedIdTransform = require('./createVersionedIdTransform');
+var createMapper = require('./createMapper');
 var locatePackage = require('../pipeline/locatePackage');
 var fetchAsText = require('../pipeline/fetchAsText');
 var translateAsIs = require('../pipeline/translateAsIs');
@@ -23,6 +24,7 @@ function hooksFromMetadata (context) {
 		hooks: {
 			normalize: createNormalizer(
 				createVersionedIdTransform(context),
+				createMapper(context, normalizeCjs),
 				normalizeCjs
 			),
 			locate: withContext(context, locatePackage),

--- a/lib/hooksFromMetadata.js
+++ b/lib/hooksFromMetadata.js
@@ -6,7 +6,7 @@ var metadata = require('./metadata');
 var normalizeCjs = require('../pipeline/normalizeCjs');
 var createNormalizer = require('./createNormalizer');
 var createVersionedIdTransform = require('./createVersionedIdTransform');
-var createMapper = require('./createMapper');
+var createPackageMapper = require('./createPackageMapper');
 var locatePackage = require('../pipeline/locatePackage');
 var fetchAsText = require('../pipeline/fetchAsText');
 var translateAsIs = require('../pipeline/translateAsIs');
@@ -24,7 +24,7 @@ function hooksFromMetadata (context) {
 		hooks: {
 			normalize: createNormalizer(
 				createVersionedIdTransform(context),
-				createMapper(context),
+				createPackageMapper(context),
 				normalizeCjs
 			),
 			locate: withContext(context, locatePackage),

--- a/lib/hooksFromMetadata.js
+++ b/lib/hooksFromMetadata.js
@@ -24,7 +24,7 @@ function hooksFromMetadata (context) {
 		hooks: {
 			normalize: createNormalizer(
 				createVersionedIdTransform(context),
-				createMapper(context, normalizeCjs),
+				createMapper(context),
 				normalizeCjs
 			),
 			locate: withContext(context, locatePackage),

--- a/lib/metadata/npm.js
+++ b/lib/metadata/npm.js
@@ -3,6 +3,8 @@
 /** @author John Hann */
 var path = require('../path');
 var base = require('./base');
+var createUid = require('../uid').create;
+var normalize = require('../../pipeline/normalizeCjs');
 
 var npmCrawler = Object.create(base);
 
@@ -18,8 +20,8 @@ npmCrawler.setPackage = function (name) {
 	return name;
 };
 
-npmCrawler.createDescriptor =  function (metadata) {
-	var descr;
+npmCrawler.createDescriptor = function (metadata) {
+	var descr, pkgRoot;
 	descr = base.createDescriptor.call(this, metadata);
 	descr.metaType = 'npm';
 	descr.moduleType = metadata.moduleType || ['node'];
@@ -30,8 +32,19 @@ npmCrawler.createDescriptor =  function (metadata) {
 		if (typeof metadata.browser === "string") {
 			descr.main = path.removeExt(metadata.browser);
 		} else {
-			descr.map = metadata.browser;
+			pkgRoot = createUid(descr, descr.name + "/index");
+			descr.map = normalizeMap(metadata.browser, pkgRoot);
 		}
 	}
 	return descr;
 };
+
+function normalizeMap (map, refId) {
+	var normalized = {}, path;
+	for (path in map) {
+		normalized[normalize(path, refId)] = map[path]
+			? normalize(map[path], refId)
+			: false;
+	}
+	return normalized;
+}

--- a/lib/metadata/npm.js
+++ b/lib/metadata/npm.js
@@ -26,5 +26,12 @@ npmCrawler.createDescriptor =  function (metadata) {
 	if (metadata.main) {
 		descr.main = path.removeExt(metadata.main);
 	}
+	if (metadata.browser) {
+		if (typeof metadata.browser === "string") {
+			descr.main = path.removeExt(metadata.browser);
+		} else {
+			descr.map = metadata.browser;
+		}
+	}
 	return descr;
 };

--- a/lib/metadata/npm.js
+++ b/lib/metadata/npm.js
@@ -3,7 +3,6 @@
 /** @author John Hann */
 var path = require('../path');
 var base = require('./base');
-var createUid = require('../uid').create;
 var normalize = require('../../pipeline/normalizeCjs');
 
 var npmCrawler = Object.create(base);
@@ -32,14 +31,14 @@ npmCrawler.createDescriptor = function (metadata) {
 		if (typeof metadata.browser === "string") {
 			descr.main = path.removeExt(metadata.browser);
 		} else {
-			pkgRoot = createUid(descr, descr.name + "/index");
-			descr.map = normalizeMap(metadata.browser, pkgRoot);
+			pkgRoot = descr.name + "/index";
+			descr.map = this.normalizeMap(metadata.browser, pkgRoot);
 		}
 	}
 	return descr;
 };
 
-function normalizeMap (map, refId) {
+npmCrawler.normalizeMap = function (map, refId) {
 	var normalized = {}, path;
 	for (path in map) {
 		normalized[normalize(path, refId)] = map[path]
@@ -47,4 +46,4 @@ function normalizeMap (map, refId) {
 			: false;
 	}
 	return normalized;
-}
+};

--- a/lib/uid.js
+++ b/lib/uid.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 exports.create = createUid;
 exports.parse = parseUid;
-exports.getModuleName = getModuleName;
+exports.getName = getName;
 
 function createUid (descriptor, normalized) {
 	return /*descriptor.metaType + ':' +*/ descriptor.name
@@ -25,6 +25,6 @@ function parseUid (uid) {
 }
 
 
-function getModuleName (uid) {
-	return uid.split("#")[1];
+function getName (uid) {
+	return uid.split("#").pop();
 }

--- a/lib/uid.js
+++ b/lib/uid.js
@@ -3,12 +3,14 @@
 /** @author John Hann */
 exports.create = createUid;
 exports.parse = parseUid;
+exports.getModuleName = getModuleName;
 
 function createUid (descriptor, normalized) {
 	return /*descriptor.metaType + ':' +*/ descriptor.name
 		+ (descriptor.version ? '@' + descriptor.version : '')
 		+ (normalized ? '#' + normalized : '');
 }
+
 
 function parseUid (uid) {
 	var uparts = uid.split('#');
@@ -19,5 +21,10 @@ function parseUid (uid) {
 		pkgName: nparts.shift(),
 		modulePath: nparts.join('/'),
 		pkgUid: uparts[0]
-	}
+	};
+}
+
+
+function getModuleName (uid) {
+	return uid.split("#")[1];
 }

--- a/rave.js
+++ b/rave.js
@@ -1911,12 +1911,14 @@ function compareFilters (a, b) {
 
 ;define('rave/lib/uid', ['require', 'exports', 'module'], function (require, exports, module, define) {exports.create = createUid;
 exports.parse = parseUid;
+exports.getName = getName;
 
 function createUid (descriptor, normalized) {
 	return /*descriptor.metaType + ':' +*/ descriptor.name
 		+ (descriptor.version ? '@' + descriptor.version : '')
 		+ (normalized ? '#' + normalized : '');
 }
+
 
 function parseUid (uid) {
 	var uparts = uid.split('#');
@@ -1927,7 +1929,25 @@ function parseUid (uid) {
 		pkgName: nparts.shift(),
 		modulePath: nparts.join('/'),
 		pkgUid: uparts[0]
-	}
+	};
+}
+
+
+function getName (uid) {
+	return uid.split("#").pop();
+}
+
+});
+
+
+;define('rave/pipeline/normalizeCjs', ['require', 'exports', 'module', 'rave/lib/path'], function (require, exports, module, $cram_r0, define) {var path = $cram_r0;
+
+module.exports = normalizeCjs;
+
+var reduceLeadingDots = path.reduceLeadingDots;
+
+function normalizeCjs (name, refererName, refererUrl) {
+	return reduceLeadingDots(String(name), refererName || '');
 }
 
 });
@@ -1942,19 +1962,6 @@ function fetchAsText (load) {
 		fetchText(load.address, resolve, reject);
 	});
 
-}
-
-});
-
-
-;define('rave/pipeline/normalizeCjs', ['require', 'exports', 'module', 'rave/lib/path'], function (require, exports, module, $cram_r0, define) {var path = $cram_r0;
-
-module.exports = normalizeCjs;
-
-var reduceLeadingDots = path.reduceLeadingDots;
-
-function normalizeCjs (name, refererName, refererUrl) {
-	return reduceLeadingDots(String(name), refererName || '');
 }
 
 });

--- a/test/lib/createMapper.js
+++ b/test/lib/createMapper.js
@@ -25,24 +25,15 @@ buster.testCase('createMapper', {
 	},
 
 	'should replace the module id if it is in the map': function () {
-		var normalize = this.spy(fakeNormalize);
-		var packages = {'a': {map: {'./some/path': './foo.js'}}};
-		var map = createMapper({packages: packages}, normalize);
-		assert.equals(map(normalize('./some/path.js', 'a'), 'a'), 'a#./FOO');
+		var packages = {'a': {map: {'foo#foo/some/path': 'foo#foo/browser'}}};
+		var map = createMapper({packages: packages});
+		assert.equals(map('foo#foo/some/path', 'a'), 'foo#foo/browser');
 	},
 
 	'should replace the module id with rave/lib/blank if it is mapped to false': function () {
-		var normalize = this.spy(fakeNormalize);
-		var packages = {'a': {map: {'./some/path': false}}};
-		var map = createMapper({packages: packages}, normalize);
-		assert.equals(map(normalize('./some/path.js', 'a'), 'a'), 'rave/lib/blank');
+		var packages = {'a': {map: {'bar': false}}};
+		var map = createMapper({packages: packages});
+		assert.equals(map('bar', 'a'), 'rave/lib/blank');
 	}
 
 });
-
-// we want to make sure the normalize function is used in the right places
-// so create a fake normalizer that incorporates the args into the return value
-// as well as does some processing to the module id
-function fakeNormalize(id, refUid) {
-	return refUid + '#' + id.toUpperCase().replace(".JS", "");
-}

--- a/test/lib/createMapper.js
+++ b/test/lib/createMapper.js
@@ -1,0 +1,48 @@
+var buster = require('buster');
+var assert = buster.assert;
+var refute = buster.refute;
+var fail = buster.assertions.fail;
+
+var createMapper = require('../../lib/createMapper');
+
+buster.testCase('createMapper', {
+
+	'should create a function': function () {
+		var map = createMapper({}, function () {});
+		assert.isFunction(map);
+	},
+
+	'should not change the module id if there is no map': function () {
+		var packages = {'a': {}};
+		var map = createMapper({packages: packages}, function () {});
+		assert.equals(map('./some/path.js', 'a'), './some/path.js');
+	},
+
+	'should not change the module id if it is not in the map': function () {
+		var packages = {'a': {map: {'./some/other/path': './foo'}}};
+		var map = createMapper({packages: packages}, function () {});
+		assert.equals(map('./some/path.js', 'a'), './some/path.js');
+	},
+
+	'should replace the module id if it is in the map': function () {
+		var normalize = this.spy(fakeNormalize);
+		var packages = {'a': {map: {'./some/path': './foo.js'}}};
+		var map = createMapper({packages: packages}, normalize);
+		assert.equals(map(normalize('./some/path.js', 'a'), 'a'), 'a#./FOO');
+	},
+
+	'should replace the module id with rave/lib/blank if it is mapped to false': function () {
+		var normalize = this.spy(fakeNormalize);
+		var packages = {'a': {map: {'./some/path': false}}};
+		var map = createMapper({packages: packages}, normalize);
+		assert.equals(map(normalize('./some/path.js', 'a'), 'a'), 'rave/lib/blank');
+	}
+
+});
+
+// we want to make sure the normalize function is used in the right places
+// so create a fake normalizer that incorporates the args into the return value
+// as well as does some processing to the module id
+function fakeNormalize(id, refUid) {
+	return refUid + '#' + id.toUpperCase().replace(".JS", "");
+}

--- a/test/lib/createMapper.js
+++ b/test/lib/createMapper.js
@@ -8,32 +8,32 @@ var createMapper = require('../../lib/createMapper');
 buster.testCase('createMapper', {
 
 	'should create a function': function () {
-		var map = createMapper({}, function () {});
+		var map = createMapper({});
 		assert.isFunction(map);
 	},
 
 	'should not change the module id if there is no map': function () {
-		var packages = {'a': {}};
-		var map = createMapper({packages: packages}, function () {});
-		assert.equals(map('./some/path.js', 'a'), './some/path.js');
+		var packages = {'foo': {}};
+		var map = createMapper({packages: packages});
+		assert.equals(map('./some/path.js', 'foo'), './some/path.js');
 	},
 
 	'should not change the module id if it is not in the map': function () {
-		var packages = {'a': {map: {'./some/other/path': './foo'}}};
-		var map = createMapper({packages: packages}, function () {});
-		assert.equals(map('./some/path.js', 'a'), './some/path.js');
+		var packages = {'foo': {map: {'./some/other/path': './foo'}}};
+		var map = createMapper({packages: packages});
+		assert.equals(map('./some/path.js', 'foo'), './some/path.js');
 	},
 
 	'should replace the module id if it is in the map': function () {
-		var packages = {'a': {map: {'foo#foo/some/path': 'foo#foo/browser'}}};
+		var packages = {'foo': {map: {'foo/some/path': 'foo/browser'}}};
 		var map = createMapper({packages: packages});
-		assert.equals(map('foo#foo/some/path', 'a'), 'foo#foo/browser');
+		assert.equals(map('foo/some/path', 'foo'), 'foo/browser');
 	},
 
 	'should replace the module id with rave/lib/blank if it is mapped to false': function () {
-		var packages = {'a': {map: {'bar': false}}};
+		var packages = {'foo': {map: {'bar': false}}};
 		var map = createMapper({packages: packages});
-		assert.equals(map('bar', 'a'), 'rave/lib/blank');
+		assert.equals(map('bar', 'foo'), 'rave/lib/blank');
 	}
 
 });

--- a/test/lib/createNormalizer.js
+++ b/test/lib/createNormalizer.js
@@ -14,7 +14,7 @@ buster.testCase('createNormalizer', {
 		var func = createNormalizer(arg1, arg2, arg3);
 		func('a', 'b', 'c');
 		assert.alwaysCalledWithExactly(arg3, 'a', 'b', 'c');
-		assert.alwaysCalledWithExactly(arg2, 'd', 'b', 'c');
+		assert.alwaysCalledWithExactly(arg2, 'd', 'b');
 		assert.alwaysCalledWithExactly(arg1, 'm', 'b', 'c');
 	}
 

--- a/test/lib/createNormalizer.js
+++ b/test/lib/createNormalizer.js
@@ -9,11 +9,13 @@ buster.testCase('createNormalizer', {
 
 	'should create a function that calls its arguments': function () {
 		var arg1 = this.spy(),
-			arg2 = this.spy(function () { return 'd'; });
-		var func = createNormalizer(arg1, arg2);
+			arg2 = this.spy(function () { return 'm'; }),
+			arg3 = this.spy(function () { return 'd'; });
+		var func = createNormalizer(arg1, arg2, arg3);
 		func('a', 'b', 'c');
-		assert.alwaysCalledWithExactly(arg2, 'a', 'b', 'c');
-		assert.alwaysCalledWithExactly(arg1, 'd', 'b', 'c');
+		assert.alwaysCalledWithExactly(arg3, 'a', 'b', 'c');
+		assert.alwaysCalledWithExactly(arg2, 'd', 'b', 'c');
+		assert.alwaysCalledWithExactly(arg1, 'm', 'b', 'c');
 	}
 
 });

--- a/test/lib/createPackageMapper.js
+++ b/test/lib/createPackageMapper.js
@@ -1,0 +1,27 @@
+var buster = require('buster');
+var assert = buster.assert;
+var refute = buster.refute;
+var fail = buster.assertions.fail;
+
+var createPackageMapper = require('../../lib/createPackageMapper');
+
+buster.testCase('createPackageMapper', {
+
+	'should create a function': function () {
+		var map = createPackageMapper({});
+		assert.isFunction(map);
+	},
+
+	'should handle mapping uids': function () {
+		var packages = {'foo': {map: {'foo/some/path': 'foo/browser'}}};
+		var map = createPackageMapper({packages: packages});
+		assert.equals(map('foo@1.0.0#foo/some/path', 'foo'), 'foo/browser');
+	},
+
+	'should handle mapping module names': function () {
+		var packages = {'foo': {map: {'foo/some/path': 'foo/browser'}}};
+		var map = createPackageMapper({packages: packages});
+		assert.equals(map('foo/some/path', 'foo'), 'foo/browser');
+	}
+
+});

--- a/test/lib/metadata/npm.js
+++ b/test/lib/metadata/npm.js
@@ -50,12 +50,17 @@ buster.testCase('lib/metadata/npm', {
 			assert.equals(dsc.main, 'deep/path/to/browser');
 		},
 
-		'should use browser field as map if it is an object': function () {
+		'should use a normalized browser field as map if it is an object': function () {
+			this.stub(npm, 'normalizeMap', function (moduleName) {
+				return moduleName;
+			});
+
 			var browser = {
 				'a': 'b',
 				'./relative/module': './relative/browser/module',
 				'fs': false
 			};
+
 			var dsc = npm.createDescriptor({
 				name: 'foo',
 				version: '2.0.0',
@@ -64,10 +69,21 @@ buster.testCase('lib/metadata/npm', {
 			});
 
 			assert.equals(dsc.main, 'deep/path/to/main');
-			assert.equals(dsc.map, {
+			assert.equals(dsc.map, browser);
+			assert.calledOnceWith(npm.normalizeMap, browser, 'foo/index');
+		}
+	},
+
+	normalizeMap: {
+		'should normalize each key/value in an object': function () {
+			assert.equals(npm.normalizeMap({
 				'a': 'b',
-				'fs': false,
-				'foo/relative/module': 'foo/relative/browser/module'
+				'./relative/module': './relative/browser/module',
+				'fs': false
+			}, 'foo/index'), {
+				'a': 'b',
+				'foo/relative/module': 'foo/relative/browser/module',
+				'fs': false
 			});
 		}
 	}

--- a/test/lib/metadata/npm.js
+++ b/test/lib/metadata/npm.js
@@ -39,6 +39,30 @@ buster.testCase('lib/metadata/npm', {
 			var dsc = npm.createDescriptor({});
 
 			assert.equals(dsc.moduleType, ['node']);
+		},
+
+		'should use browser field as main if it is a string': function () {
+			var dsc = npm.createDescriptor({
+				main: 'deep/path/to/main.js',
+				browser: 'deep/path/to/browser.js'
+			});
+
+			assert.equals(dsc.main, 'deep/path/to/browser');
+		},
+
+		'should use browser field as map if it is an object': function () {
+			var browser = {
+				'a': 'b',
+				'./relative/module': './relative/browser/module',
+				'fs': false
+			};
+			var dsc = npm.createDescriptor({
+				main: 'deep/path/to/main.js',
+				browser: browser
+			});
+
+			assert.equals(dsc.main, 'deep/path/to/main');
+			assert.equals(dsc.map, browser);
 		}
 	}
 

--- a/test/lib/metadata/npm.js
+++ b/test/lib/metadata/npm.js
@@ -57,12 +57,18 @@ buster.testCase('lib/metadata/npm', {
 				'fs': false
 			};
 			var dsc = npm.createDescriptor({
+				name: 'foo',
+				version: '2.0.0',
 				main: 'deep/path/to/main.js',
 				browser: browser
 			});
 
 			assert.equals(dsc.main, 'deep/path/to/main');
-			assert.equals(dsc.map, browser);
+			assert.equals(dsc.map, {
+				'a': 'b',
+				'fs': false,
+				'foo@2.0.0#foo/relative/module': 'foo@2.0.0#foo/relative/browser/module'
+			});
 		}
 	}
 

--- a/test/lib/metadata/npm.js
+++ b/test/lib/metadata/npm.js
@@ -67,7 +67,7 @@ buster.testCase('lib/metadata/npm', {
 			assert.equals(dsc.map, {
 				'a': 'b',
 				'fs': false,
-				'foo@2.0.0#foo/relative/module': 'foo@2.0.0#foo/relative/browser/module'
+				'foo/relative/module': 'foo/relative/browser/module'
 			});
 		}
 	}

--- a/test/lib/uid.js
+++ b/test/lib/uid.js
@@ -45,6 +45,15 @@ buster.testCase('lib/uid', {
 			assert.equals(parsed.modulePath, 'c/d');
 			assert.equals(parsed.pkgUid, 'a');
 		}
+	},
+
+	getName: {
+		'should handle module uids': function () {
+			assert.equals(uid.getName('a#b/c/d'), 'b/c/d');
+		},
+		'should handle module names': function () {
+			assert.equals(uid.getName('b/c/d'), 'b/c/d');
+		}
 	}
 
 });


### PR DESCRIPTION
Based on the unofficial spec
https://gist.github.com/defunctzombie/4339901

This is not complete yet, but I just wanted to get some feedback before I proceed.

If the browser field is a string, I simply map that onto descriptor's main, since that what it actually means. If the browser field is an object, I create a new descriptor.map property which is then used in the normalization hook. This way both loading and requiring modules goes through the mapper

There's one more thing missing which is being able to set modules to `false` in the map to prevent them from being loaded. I was thinking about creating a `rave/blank` module and map it to that.

If this sounds ok, I'll proceed with making sure it actually works well (i.e. write tests).
