### PR TITLE
Make bower crawler more robust

### DIFF
--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -36,6 +36,7 @@ bowerCrawler.fetchAltMetaFile = function () {
 
 bowerCrawler.createDescriptor = function (metadata) {
 	var descr, mainPath;
+	metadata.version = metadata.version || "0.0.0";
 	descr = base.createDescriptor.call(this, metadata);
 	descr.metaType = 'bower';
 	descr.moduleType = this.findModuleType(metadata);
@@ -72,4 +73,4 @@ bowerCrawler.findModuleType = function findModuleType (meta) {
 
 bowerCrawler.isGlobalScript = function (descr) {
 	return descr.moduleType[0] === 'globals' && descr.moduleType.length === 1;
-}
+};

--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -22,6 +22,10 @@ bowerCrawler.fetchMetaFile = function () {
 	return require.async(url)['catch'](this.fetchAltMetaFile.bind(this));
 };
 
+// If a bower component has no bower.json, we try fetching
+// package.json instead. However, we don't want to use the
+// dependencies hash from package.json since those are npm
+// dependencies, which won't be installed by bower.
 bowerCrawler.fetchAltMetaFile = function () {
 	var url = path.joinPaths(this.pkgRoot, this.altMetaName);
 	return require.async(url).then(function (metadata) {

--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -19,7 +19,9 @@ bowerCrawler.altMetaName = 'package.json';
 
 bowerCrawler.fetchMetaFile = function () {
 	var url = path.joinPaths(this.pkgRoot, this.metaName);
-	return require.async(url)['catch'](this.fetchAltMetaFile.bind(this));
+	return require.async(url)
+		['catch'](this.fetchAltMetaFile.bind(this))
+		['catch'](this.createMetaFile.bind(this));
 };
 
 // If a bower component has no bower.json, we try fetching
@@ -36,6 +38,14 @@ bowerCrawler.fetchAltMetaFile = function () {
 			moduleType: metadata.moduleType || ["node"]
 		};
 	});
+};
+
+bowerCrawler.createMetaFile = function () {
+	return {
+		name: this.pkgName,
+		version: "0.0.0",
+		main: this.pkgName
+	};
 };
 
 bowerCrawler.createDescriptor = function (metadata) {

--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -15,16 +15,15 @@ bowerCrawler.libFolder = 'bower_components';
 
 bowerCrawler.metaName = 'bower.json';
 
-bowerCrawler.altMetaName = 'package.json';
-
 bowerCrawler.fetchMetaFile = function () {
 	var url = path.joinPaths(this.pkgRoot, this.metaName);
-	return require.async(url)['catch'](this.fetchAltMetaFile.bind(this));
-};
-
-bowerCrawler.fetchAltMetaFile = function () {
-	var url = path.joinPaths(this.pkgRoot, this.altMetaName);
-	return require.async(url);
+	return require.async(url)['catch'](function () {}).then(function (metadata) {
+		return metadata || {
+			name: this.pkgName,
+			version: "0.0.0",
+			main: this.pkgName,
+		};
+	}.bind(this));
 };
 
 bowerCrawler.createDescriptor = function (metadata) {

--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -15,15 +15,23 @@ bowerCrawler.libFolder = 'bower_components';
 
 bowerCrawler.metaName = 'bower.json';
 
+bowerCrawler.altMetaName = 'package.json';
+
 bowerCrawler.fetchMetaFile = function () {
 	var url = path.joinPaths(this.pkgRoot, this.metaName);
-	return require.async(url)['catch'](function () {}).then(function (metadata) {
-		return metadata || {
-			name: this.pkgName,
-			version: "0.0.0",
-			main: this.pkgName,
+	return require.async(url)['catch'](this.fetchAltMetaFile.bind(this));
+};
+
+bowerCrawler.fetchAltMetaFile = function () {
+	var url = path.joinPaths(this.pkgRoot, this.altMetaName);
+	return require.async(url).then(function (metadata) {
+		return {
+			name: metadata.name,
+			version: metadata.version,
+			main: metadata.main,
+			moduleType: metadata.moduleType || ["node"]
 		};
-	}.bind(this));
+	});
 };
 
 bowerCrawler.createDescriptor = function (metadata) {


### PR DESCRIPTION
This starts implementing #39, however I wasn't sure what to do about `main` when bower.json is missing. That could still be read from package.json.
