### PR TITLE
Apply rave.missing as default overrides from all rave extensions. See #43.

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -114,6 +114,11 @@ function gatherExtensions (context) {
 					applyOverrides(context.packages, extensionMeta.missing, true);
 				}
 
+				if (extensionMeta.overrides) {
+					// apply overrides
+					applyOverrides(context.packages, extensionMeta.overrides);
+				}
+
 				if (extensionMeta.extension) {
 					promises.push(initExtension(context, pkg.name, extensionMeta.extension));
 				}
@@ -127,8 +132,13 @@ function gatherExtensions (context) {
 function applyRavePackageMetadata (context) {
 	var rave = context.app.metadata.metadata.rave;
 
-	if (rave && rave.overrides) {
-		applyOverrides(context.packages, rave.overrides);
+	if (rave) {
+		if (rave.missing) {
+			applyOverrides(context.packages, rave.missing, true);
+		}
+		if (rave.overrides) {
+			applyOverrides(context.packages, rave.overrides);
+		}
 	}
 
 	return context;

--- a/auto.js
+++ b/auto.js
@@ -94,7 +94,7 @@ function configureLoader (context) {
 }
 
 function gatherExtensions (context) {
-	var seen, name, pkg, promises, moduleName;
+	var seen, name, pkg, promises, extensionMeta;
 	seen = {};
 	promises = [];
 	for (name in context.packages) {
@@ -104,12 +104,18 @@ function gatherExtensions (context) {
 			seen[pkg.name] = true;
 			if (pkg.metadata && pkg.metadata.rave) {
 
-				moduleName = typeof pkg.metadata.rave === 'string'
-					? pkg.metadata.rave
-					: pkg.metadata.rave.extension;
+				extensionMeta = pkg.metadata.rave;
+				if (typeof extensionMeta === 'string') {
+					extensionMeta = { extension: extensionMeta };
+				}
 
-				if (moduleName) {
-					promises.push(initExtension(context, pkg.name, moduleName));
+				if (extensionMeta.missing) {
+					// apply missing
+					applyOverrides(context.packages, extensionMeta.missing, true);
+				}
+
+				if (extensionMeta.extension) {
+					promises.push(initExtension(context, pkg.name, extensionMeta.extension));
 				}
 
 			}
@@ -128,14 +134,16 @@ function applyRavePackageMetadata (context) {
 	return context;
 }
 
-function applyOverrides (packages, overrides) {
+function applyOverrides (packages, overrides, ifMissing) {
 	var name, pkg, key, pkgOverrides;
 	for (name in overrides) {
 		pkg = packages[name];
 		if (pkg) {
 			pkgOverrides = overrides[name];
 			for (key in pkgOverrides) {
-				pkg[key] = pkgOverrides[key];
+				if (!ifMissing || typeof pkg[key] === 'undefined') {
+					pkg[key] = pkgOverrides[key];
+				}
 			}
 		}
 	}

--- a/lib/hooksFromMetadata.js
+++ b/lib/hooksFromMetadata.js
@@ -76,7 +76,7 @@ function instantiate (load) {
 }
 
 function hasModuleType (moduleType, type) {
-	return moduleType.indexOf(type) >= 0;
+	return moduleType && moduleType.indexOf(type) >= 0;
 }
 
 function guessModuleType (load) {

--- a/lib/metadata/bower.js
+++ b/lib/metadata/bower.js
@@ -50,7 +50,7 @@ bowerCrawler.createDescriptor = function (metadata) {
 	metadata.version = metadata.version || "0.0.0";
 	descr = base.createDescriptor.call(this, metadata);
 	descr.metaType = 'bower';
-	descr.moduleType = metadata.moduleType || [];
+	descr.moduleType = metadata.moduleType;
 	descr.main = metadata.main && this.findJsMain(metadata.main);
 	if (descr.main) {
 		descr.main = path.removeExt(descr.main);


### PR DESCRIPTION
Stop expecting moduleType to be an array.
Stop supplying a moduleType array, so it can be provided if missing/undefined.
