### PR TITLE
Very simple build attempt

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -112,21 +112,6 @@ function gatherExtensions (context) {
 	return Promise.all(promises);
 }
 
-function applyOverrides (packages, overrides, fromPkg, ifMissing) {
-	var name, pkg, key, pkgOverrides;
-	for (name in overrides) {
-		pkg = metadata.findDepPackage(packages, fromPkg, name);
-		if (pkg) {
-			pkgOverrides = overrides[name];
-			for (key in pkgOverrides) {
-				if (!ifMissing || typeof pkg[key] === 'undefined') {
-					pkg[key] = pkgOverrides[key];
-				}
-			}
-		}
-	}
-}
-
 function initExtension (context, packageName, moduleName) {
 	return fetchExtension(path.joinPaths(packageName, moduleName))
 		.then(extractExtensionCtor)

--- a/lib/amd/bundle.js
+++ b/lib/amd/bundle.js
@@ -4,7 +4,7 @@
 
 var metadata = require('../metadata');
 var createUid = require('../uid').create;
-var amdFactory = require('../amdFactory');
+var amdFactory = require('./factory');
 
 exports.process = process;
 

--- a/lib/amd/bundle.js
+++ b/lib/amd/bundle.js
@@ -1,0 +1,56 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var metadata = require('../metadata');
+var createUid = require('../uid').create;
+var amdFactory = require('../amdFactory');
+
+exports.process = process;
+
+// TODO: replace this sync algorithm with one that is based on register()
+// if (defines.named.length <= 1) process as before
+// else loop through defines and eval all modules sync,
+//   returning the one whose name matches load.name
+
+// TODO: register-based algorithm
+//if (defines.anon) register(defines.anon, load.name);
+//defines.named.forEach(function (def) {
+// register(def);
+//});
+
+function process (load, defines) {
+	var mainDefine, i;
+
+	for (i = 0; i < defines.length; i++) {
+		mainDefine = processOne(load, defines[i]) || mainDefine;
+	}
+
+	return mainDefine;
+
+}
+
+function processOne (load, define) {
+	var loader, packages, name, uid, defLoad, value;
+
+	loader = load.metadata.rave.loader;
+	packages = load.metadata.rave.packages;
+	name = define.name;
+	uid = getUid(packages, name);
+
+	if (uid === load.name) {
+		return define;
+	}
+	else {
+		defLoad = Object.create(load);
+		defLoad.name = uid;
+		defLoad.address = load.address + '#' + encodeURIComponent(name);
+		value = amdFactory(loader, define, defLoad)();
+		loader.set(uid, new Module(value));
+	}
+}
+
+function getUid (packages, name) {
+	var pkg = metadata.findPackage(packages, name);
+	return createUid(pkg, name);
+}

--- a/lib/amd/captureDefines.js
+++ b/lib/amd/captureDefines.js
@@ -1,11 +1,11 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
-module.exports = captureAmdDefines;
+module.exports = captureDefines;
 
 var amdEval = new Function('define', 'eval(arguments[1]);');
 
-function captureAmdDefines (source) {
+function captureDefines (source) {
 	var result, isAnon, capture;
 
 	result = { named: [] };

--- a/lib/amd/captureDefines.js
+++ b/lib/amd/captureDefines.js
@@ -3,8 +3,6 @@
 /** @author John Hann */
 module.exports = captureDefines;
 
-var amdEval = new Function('define', 'eval(arguments[1]);');
-
 function captureDefines (source) {
 	var result, isAnon, capture;
 
@@ -49,7 +47,9 @@ function captureDefines (source) {
 	// indicate we are AMD and we can handle the jqueries
 	capture.amd = { jQuery: {} };
 
-	amdEval(capture, source);
+	// Note: V8 intermittently fails if we embed eval() in new Function()
+	// and source has "use strict" in it
+	new Function('define', source).call(global, capture);
 
 	if (!result) {
 		throw new Error('AMD define not called.');

--- a/lib/amd/factory.js
+++ b/lib/amd/factory.js
@@ -3,8 +3,8 @@
 /** @author John Hann */
 module.exports = amdFactory;
 
-var es5Transform = require('./es5Transform');
-var createRequire = require('./createRequire');
+var es5Transform = require('./../es5Transform');
+var createRequire = require('./../createRequire');
 
 function amdFactory (loader, defineArgs, load) {
 	var cjsRequire, require, exports, module, scopedVars;

--- a/lib/captureAmdDefines.js
+++ b/lib/captureAmdDefines.js
@@ -1,39 +1,49 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
-module.exports = captureAmdArgs;
-
-// TODO: deal with multiple define() calls?
+module.exports = captureAmdDefines;
 
 var amdEval = new Function ('define', 'eval(arguments[1]);');
 
-function captureAmdArgs (source) {
-	var result, capture;
+function captureAmdDefines (source) {
+	var result, isAnon, capture;
+
+	result = { named: [] };
 
 	capture = function captureDefine () {
-		var args;
+		var args, def;
 
 		args = Array.prototype.slice.call(arguments);
 
 		// last arg is always the factory (or a plain value)
-		result = { factory: ensureFactory(args.pop()) };
+		def = { factory: ensureFactory(args.pop()) };
 
 		// if there are other args
 		if (args.length > 0) {
 			// get list of dependency module ids
-			result.depsList = args.pop();
+			def.depsList = args.pop();
 			// if this is a string, then there are no deps
-			if (typeof result.depsList === 'string') {
-				result.name = result.depsList;
-				delete result.depsList;
+			if (typeof def.depsList === 'string') {
+				def.name = def.depsList;
+				delete def.depsList;
 			}
 			else {
-				result.name = args.pop() || null;
+				def.name = args.pop() || null;
 			}
 			if (args.length > 0) {
 				throw new Error('Error parsing AMD source.');
 			}
 		}
+
+		if (!def.name) {
+			if (isAnon) throw new Error('Multiple anonymous defines.');
+			isAnon = true;
+			result.anon = def;
+		}
+		else {
+			result.named.push(def);
+		}
+
 	};
 
 	// indicate we are AMD and we can handle the jqueries

--- a/lib/captureAmdDefines.js
+++ b/lib/captureAmdDefines.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 module.exports = captureAmdDefines;
 
-var amdEval = new Function ('define', 'eval(arguments[1]);');
+var amdEval = new Function('define', 'eval(arguments[1]);');
 
 function captureAmdDefines (source) {
 	var result, isAnon, capture;
@@ -13,7 +13,7 @@ function captureAmdDefines (source) {
 	capture = function captureDefine () {
 		var args, def;
 
-		args = Array.prototype.slice.call(arguments);
+		args = copy(arguments);
 
 		// last arg is always the factory (or a plain value)
 		def = { factory: ensureFactory(args.pop()) };
@@ -31,7 +31,7 @@ function captureAmdDefines (source) {
 				def.name = args.pop() || null;
 			}
 			if (args.length > 0) {
-				throw new Error('Error parsing AMD source.');
+				throw new Error('Unparsable AMD define arguments: ', copy(arguments));
 			}
 		}
 
@@ -62,4 +62,8 @@ function ensureFactory (thing) {
 	return typeof thing === 'function'
 		? thing
 		: function () { return thing; }
+}
+
+function copy (thing) {
+	return Array.prototype.slice.call(thing);
 }

--- a/lib/convert/bower.js
+++ b/lib/convert/bower.js
@@ -21,6 +21,10 @@ function bowerConvert (data) {
 }
 
 function bowerFixups (data) {
+	var metadata = data.getMetadata();
+	if (metadata.moduleType) {
+		data.moduleType = metadata.moduleType;
+	}
 	data.main = path.removeExt(bowerFindJsMain(data));
 	return bowerAdjustLocation(data);
 }

--- a/lib/crawl.js
+++ b/lib/crawl.js
@@ -26,9 +26,7 @@ function crawl (rootUrls) {
 		rootUrls = rootUrls.split(/\s*,\s*/);
 	}
 	return Promise.all(rootUrls.map(crawlOne))
-		.then(function (tuples) {
-			return collapseMetadata(tuples);
-		});
+		.then(collapseMetadata);
 }
 
 function crawlOne (rootUrl) {

--- a/lib/crawl/common.js
+++ b/lib/crawl/common.js
@@ -7,7 +7,9 @@
 // main exports
 
 exports.crawl = crawl;
-exports.load = load;
+exports.load = typeof require.async !== 'undefined'
+	? load
+	: nativeLoad;
 
 // exports for testing
 
@@ -37,6 +39,10 @@ function crawl (context) {
 
 function load (context, fileUrl) {
 	return require.async(fileUrl);
+}
+
+function nativeLoad (context, fileUrl) {
+	return Promise.resolve(require(fileUrl));
 }
 
 function childIterator (context, names) {

--- a/lib/nodeFactory.js
+++ b/lib/nodeFactory.js
@@ -6,11 +6,6 @@ module.exports = nodeFactory;
 var es5Transform = require('./es5Transform');
 var createRequire = require('./createRequire');
 
-var nodeEval = new Function(
-	'require', 'exports', 'module', 'global',
-	'eval(arguments[4]);'
-);
-
 var _global;
 
 _global = typeof global !== 'undefined' ? global : window;
@@ -26,7 +21,12 @@ function nodeFactory (loader, load) {
 
 	return function () {
 		// TODO: use loader.global when es6-module-loader implements it
-		nodeEval(require, module.exports, module, _global, source);
+		// Note: V8 intermittently fails if we embed eval() in new Function()
+		// and source has "use strict" in it
+		var nodeEval = new Function(
+			'require', 'exports', 'module', 'global', source
+		);
+		nodeEval.call(exports, require, exports, module, _global, source);
 		// figure out what author intended to export
 		return exports === module.exports
 			? exports // a set of named exports

--- a/pipeline/instantiateAmd.js
+++ b/pipeline/instantiateAmd.js
@@ -2,8 +2,8 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 var findRequires = require('../lib/find/requires');
-var captureAmdDefines = require('../lib/captureAmdDefines');
-var amdFactory = require('../lib/amdFactory');
+var captureDefines = require('../lib/amd/captureDefines');
+var amdFactory = require('../lib/amd/factory');
 var addSourceUrl = require('../lib/addSourceUrl');
 var processBundle = require('../lib/amd/bundle').process;
 
@@ -61,7 +61,7 @@ function instantiateAmd (load) {
 
 function captureOrThrow (load) {
 	try {
-		return captureAmdDefines(load.source);
+		return captureDefines(load.source);
 	}
 	catch (ex) {
 		ex.message = 'Error while parsing AMD: '

--- a/pipeline/instantiateAmd.js
+++ b/pipeline/instantiateAmd.js
@@ -2,16 +2,17 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 var findRequires = require('../lib/find/requires');
-var captureAmdArgs = require('../lib/captureAmdArgs');
+var captureAmdDefines = require('../lib/captureAmdDefines');
 var amdFactory = require('../lib/amdFactory');
 var addSourceUrl = require('../lib/addSourceUrl');
+var parseUid = require('../lib/uid').parse;
 
 module.exports = instantiateAmd;
 
 var scopedVars = ['require', 'exports', 'module'];
 
 function instantiateAmd (load) {
-	var loader, defineArgs, arity, factory, deps, isCjs, i;
+	var loader, defines, mainDefine, arity, factory, deps, isCjs, i;
 
 	loader = load.metadata.rave.loader;
 
@@ -20,21 +21,25 @@ function instantiateAmd (load) {
 		load.source = addSourceUrl(load.address, load.source);
 	}
 
-	// the safest way to capture the many define() variations is to run it
-	defineArgs = captureOrThrow(load);
-	arity = defineArgs.factory.length;
+	// the surest way to capture the many define() variations is to run it
+	defines = captureOrThrow(load);
+	mainDefine = defines.anon || defines.named.pop();
+
+	// TODO: figure out which named define is the right one
+	// TODO: do something with the remaining named defines
+
+	arity = mainDefine.factory.length;
 
 	// copy deps so we can remove items below!
 	deps = defineArgs.depsList ? defineArgs.depsList.slice() : [];
 
-	if (defineArgs.depsList == null && arity > 0) {
-		// is using load.source faster than defineArgs.factory.toString()?
-		defineArgs.requires = findOrThrow(load);
-		defineArgs.depsList = scopedVars.slice(0, arity);
-		deps = deps.concat(defineArgs.requires);
+	if (mainDefine.depsList == null && arity > 0) {
+		mainDefine.requires = findOrThrow(load, mainDefine.factory.toString());
+		mainDefine.depsList = scopedVars.slice(0, arity);
+		deps = deps.concat(mainDefine.requires);
 	}
 
-	factory = amdFactory(loader, defineArgs, load);
+	factory = amdFactory(loader, mainDefine, load);
 
 	// remove "require", "exports", "module" from loader deps
 	for (i = deps.length - 1; i >= 0; i--) {
@@ -53,18 +58,18 @@ function instantiateAmd (load) {
 
 function captureOrThrow (load) {
 	try {
-		return captureAmdArgs(load.source);
+		return captureAmdDefines(load.source);
 	}
 	catch (ex) {
-		ex.message = 'Error while capturing AMD define: '
+		ex.message = 'Error while parsing AMD: '
 			+ load.name + '. ' + ex.message;
 		throw ex;
 	}
 }
 
-function findOrThrow (load) {
+function findOrThrow (load, source) {
 	try {
-		return findRequires(load.source);
+		return findRequires(source);
 	}
 	catch (ex) {
 		ex.message += ' ' + load.name + ' ' + load.address;

--- a/rave.js
+++ b/rave.js
@@ -1547,6 +1547,20 @@ function translateAsIs (load) {
 });
 
 
+;define('rave/lib/beget', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = beget;
+
+function Begetter () {}
+function beget (base) {
+	var obj;
+	Begetter.prototype = base;
+	obj = new Begetter();
+	Begetter.prototype = null;
+	return obj;
+}
+
+});
+
+
 ;define('rave/lib/path', ['require', 'exports', 'module'], function (require, exports, module, define) {var absUrlRx, findDotsRx;
 
 absUrlRx = /^\/|^[^:]+:\/\//;
@@ -1684,20 +1698,6 @@ function splitDirAndFile (url) {
 		parts.join('/'),
 		file
 	];
-}
-
-});
-
-
-;define('rave/lib/beget', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = beget;
-
-function Begetter () {}
-function beget (base) {
-	var obj;
-	Begetter.prototype = base;
-	obj = new Begetter();
-	Begetter.prototype = null;
-	return obj;
 }
 
 });
@@ -2017,19 +2017,6 @@ function rxStringContents (rx) {
 });
 
 
-;define('rave/pipeline/normalizeCjs', ['require', 'exports', 'module', 'rave/lib/path'], function (require, exports, module, $cram_r0, define) {var path = $cram_r0;
-
-module.exports = normalizeCjs;
-
-var reduceLeadingDots = path.reduceLeadingDots;
-
-function normalizeCjs (name, refererName, refererUrl) {
-	return reduceLeadingDots(String(name), refererName || '');
-}
-
-});
-
-
 ;define('rave/pipeline/fetchAsText', ['require', 'exports', 'module', 'rave/lib/fetchText'], function (require, exports, module, $cram_r0, define) {module.exports = fetchAsText;
 
 var fetchText = $cram_r0;
@@ -2039,6 +2026,19 @@ function fetchAsText (load) {
 		fetchText(load.address, resolve, reject);
 	});
 
+}
+
+});
+
+
+;define('rave/pipeline/normalizeCjs', ['require', 'exports', 'module', 'rave/lib/path'], function (require, exports, module, $cram_r0, define) {var path = $cram_r0;
+
+module.exports = normalizeCjs;
+
+var reduceLeadingDots = path.reduceLeadingDots;
+
+function normalizeCjs (name, refererName, refererUrl) {
+	return reduceLeadingDots(String(name), refererName || '');
 }
 
 });

--- a/rave.js
+++ b/rave.js
@@ -111,7 +111,7 @@
         handler.q = [];
 
         // Create and return the promise (reusing the callback variable)
-        callback.call(callback = { then: function (resolved, rejected) { return handler(resolved, rejected); },
+        callback.call(callback = { then: function (resolved, rejected) { return handler(resolved, rejected); }, 
                                     catch: function (rejected)           { return handler(0,        rejected); } },
                       function(value)  { handler(is, 1,  value); },
                       function(reason) { handler(is, 0, reason); });
@@ -176,24 +176,24 @@
 
     /*
     *********************************************************************************************
-
+      
       Loader Polyfill
 
         - Implemented exactly to the 2013-12-02 Specification Draft -
           https://github.com/jorendorff/js-loaders/blob/e60d3651/specs/es6-modules-2013-12-02.pdf
           with the only exceptions as described here
 
-        - Abstract functions have been combined where possible, and their associated functions
+        - Abstract functions have been combined where possible, and their associated functions 
           commented
 
-        - Declarative Module Support is entirely disabled, and an error will be thrown if
+        - Declarative Module Support is entirely disabled, and an error will be thrown if 
           the instantiate loader hook returns undefined
 
         - With this assumption, instead of Link, LinkDynamicModules is run directly
 
         - ES6 support is thus provided through the translate function of the System loader
 
-        - EnsureEvaluated is removed, but may in future implement dynamic execution pending
+        - EnsureEvaluated is removed, but may in future implement dynamic execution pending 
           issue - https://github.com/jorendorff/js-loaders/issues/63
 
         - Realm implementation is entirely omitted. As such, Loader.global and Loader.realm
@@ -245,7 +245,7 @@
     }
 
     // Define an IE-friendly shim good-enough for purposes
-    var indexOf = Array.prototype.indexOf || function (item) {
+    var indexOf = Array.prototype.indexOf || function (item) { 
       for (var i = 0, thisLen = this.length; i < thisLen; i++) {
         if (this[i] === item) {
           return i;
@@ -308,7 +308,7 @@
       );
     }
     function proceedToFetch(loader, load, p) {
-      proceedToTranslate(loader, load,
+      proceedToTranslate(loader, load, 
         p
         // CallFetch
         .then(function(address) {
@@ -316,7 +316,7 @@
             return undefined;
           load.address = address;
           return loader.fetch({ name: load.name, metadata: load.metadata, address: address });
-        })
+        })        
       );
     }
     function proceedToTranslate(loader, load, p) {
@@ -390,7 +390,7 @@
         for (var i = 0, l = linkSets.length; i < l; i++)
           updateLinkSetOnLoad(linkSets[i], load);
       }
-
+      
       // LoadFailed
       , function(exc) {
         assert('is loading on fail', load.status == 'loading');
@@ -462,7 +462,7 @@
           return;
         }
       } */
-
+      
       if (linkSet.loadingCount > 0)
         return;
 
@@ -644,7 +644,7 @@
           throw new TypeError('Realms not implemented in polyfill');
         }
       });
-
+      
       this._modules = {};
       this._loads = [];
     }
@@ -734,21 +734,21 @@
 
     /*
     *********************************************************************************************
-
+      
       System Loader Implementation
 
         - Implemented to https://github.com/jorendorff/js-loaders/blob/master/browser-loader.js,
           except for Instantiate function
 
-        - Instantiate function determines if ES6 module syntax is being used, if so parses with
+        - Instantiate function determines if ES6 module syntax is being used, if so parses with 
           Traceur and returns a dynamic InstantiateResult for loading ES6 module syntax in ES5.
-
-        - Custom loaders thus can be implemented by using this System.instantiate function as
+        
+        - Custom loaders thus can be implemented by using this System.instantiate function as 
           the fallback loading scenario, after other module format detections.
 
         - Traceur is loaded dynamically when module syntax is detected by a regex (with over-
-          classification), either from require('traceur') on the server, or the
-          'data-traceur-src' property on the current script in the browser, or if not set,
+          classification), either from require('traceur') on the server, or the 
+          'data-traceur-src' property on the current script in the browser, or if not set, 
           'traceur.js' in the same URL path as the current script in the browser.
 
         - <script type="module"> supported, but <module> tag not
@@ -787,10 +787,10 @@
         });
         return output.join('').replace(/^\//, input.charAt(0) === '/' ? '/' : '');
       }
-
+     
       href = parseURI(href || '');
       base = parseURI(base || '');
-
+     
       return !href || !base ? null : (href.protocol || base.protocol) +
         (href.protocol || href.authority ? href.authority : base.authority) +
         removeDotSegments(href.protocol || href.authority || href.pathname.charAt(0) === '/' ? href.pathname : (href.pathname ? ((base.authority && !base.pathname ? '/' : '') + base.pathname.slice(0, base.pathname.lastIndexOf('/') + 1) + href.pathname) : base.pathname)) +
@@ -949,7 +949,7 @@
         }
 
         // normal eval (non-module code)
-        // note that anonymous modules (load.name == undefined) are always
+        // note that anonymous modules (load.name == undefined) are always 
         // anonymous <module> tags, so we use Traceur for these
         if (!load.metadata.es6 && load.name && (load.metadata.es6 === false || !load.source.match(es6RegEx))) {
           return {
@@ -1072,7 +1072,7 @@
 
     // es6 module forwarding - allow detecting without Traceur
     var aliasRegEx = /^\s*export\s*\*\s*from\s*(?:'([^']+)'|"([^"]+)")/;
-
+    
     // dynamically load traceur when needed
     // populates the traceur, reporter and moduleLoaderTransfomer variables
 
@@ -1089,7 +1089,7 @@
         return Promise.resolve(require('traceur'));
       }).call(exports.System, 'traceur', { address: traceurSrc }).then(function(_traceur) {
         traceurPromise = null;
-
+        
         if (isBrowser)
           _traceur = global.traceur;
 
@@ -1108,7 +1108,7 @@
     function createModuleLoaderTransformer(ParseTreeFactory, ParseTreeTransformer) {
       var createAssignmentExpression = ParseTreeFactory.createAssignmentExpression;
       var createVariableDeclaration = ParseTreeFactory.createVariableDeclaration;
-
+      
       var createCallExpression = ParseTreeFactory.createCallExpression;
 
       var createVariableDeclarationList = ParseTreeFactory.createVariableDeclarationList;
@@ -1213,13 +1213,13 @@
             return exportStarStatement;
           }
         }
-
+        
         // export var p = 4;
         else if (declaration.type == 'VARIABLE_STATEMENT') {
           // export var p = ...
           var varDeclaration = declaration.declarations.declarations[0];
           varDeclaration.initialiser = createAssignmentExpression(
-            this.createExportExpression(varDeclaration.lvalue.identifierToken.value),
+            this.createExportExpression(varDeclaration.lvalue.identifierToken.value), 
             this.transformAny(varDeclaration.initialiser)
           );
           return declaration;
@@ -1227,9 +1227,9 @@
         // export function q() {}
         else if (declaration.type == 'FUNCTION_DECLARATION') {
           var varDeclaration = createVariableDeclaration(
-            declaration.name.identifierToken.value,
+            declaration.name.identifierToken.value, 
             createAssignmentStatement(
-              this.createExportExpression(declaration.name.identifierToken.value),
+              this.createExportExpression(declaration.name.identifierToken.value), 
               this.transformAny(declaration)
             )
           );
@@ -1239,11 +1239,11 @@
         // export default ...
         else if (declaration.type == 'EXPORT_DEFAULT') {
           return createAssignmentStatement(
-            this.createExportExpression('default'),
+            this.createExportExpression('default'), 
             this.transformAny(declaration.expression)
           );
         }
-
+         
         return tree;
       }
       return ModuleLoaderTransformer;
@@ -2282,11 +2282,6 @@ function getExports (names, value) {
 var es5Transform = $cram_r0;
 var createRequire = $cram_r1;
 
-var nodeEval = new Function(
-	'require', 'exports', 'module', 'global',
-	'eval(arguments[4]);'
-);
-
 var _global;
 
 _global = typeof global !== 'undefined' ? global : window;
@@ -2302,7 +2297,12 @@ function nodeFactory (loader, load) {
 
 	return function () {
 		// TODO: use loader.global when es6-module-loader implements it
-		nodeEval(require, module.exports, module, _global, source);
+		// Note: V8 intermittently fails if we embed eval() in new Function()
+		// and source has "use strict" in it
+		var nodeEval = new Function(
+			'require', 'exports', 'module', 'global', source
+		);
+		nodeEval.call(exports, require, exports, module, _global, source);
 		// figure out what author intended to export
 		return exports === module.exports
 			? exports // a set of named exports

--- a/test/lib/amd/captureDefines.js
+++ b/test/lib/amd/captureDefines.js
@@ -3,14 +3,14 @@ var assert = buster.assert;
 var refute = buster.refute;
 var fail = buster.assertions.fail;
 
-var captureAmdArgs = require('../../lib/captureAmdDefines');
+var captureDefines = require('../../../lib/amd/captureDefines');
 
 var nameOptions = { '': 1, 'name': 1 };
 var depCounts = { 'none': 1, 0: 1, 1: 1, 3: 1 };
 var factoryOptions = { '""': 1, '{}': 1, 'function () {}': 1 };
 var depsList = [ 'dep1', 'dep2', 'dep3' ];
 
-buster.testCase('captureAmdDefines', {
+buster.testCase('rave/lib/amd/captureDefines', {
 
 	'should not fail on many variations of define()': function () {
 		for (var name in nameOptions) {
@@ -21,7 +21,7 @@ buster.testCase('captureAmdDefines', {
 						: depsList.slice(0, depCount);
 					var def = generateDefine(name, deps, factory);
 					refute.exception(function () {
-						captureAmdArgs(def);
+						captureDefines(def);
 					});
 				}
 			}
@@ -31,25 +31,25 @@ buster.testCase('captureAmdDefines', {
 	'should always return a factory': function () {
 		var def;
 		def = generateDefine(null, null, '{}');
-		assert.isFunction(captureAmdArgs(def).anon.factory, 'factory is object');
+		assert.isFunction(captureDefines(def).anon.factory, 'factory is object');
 		def = generateDefine(null, null, '"foo"');
-		assert.isFunction(captureAmdArgs(def).anon.factory, 'factory is string');
+		assert.isFunction(captureDefines(def).anon.factory, 'factory is string');
 		def = generateDefine(null, null, '/foo/g');
-		assert.isFunction(captureAmdArgs(def).anon.factory, 'factory is RegExp');
+		assert.isFunction(captureDefines(def).anon.factory, 'factory is RegExp');
 	},
 
 	'should detect a named module': function () {
 		var def;
 		def = generateDefine('foo', null, '{}');
-		assert.equals('foo', captureAmdArgs(def).named[0].name);
+		assert.equals('foo', captureDefines(def).named[0].name);
 	},
 
 	'should detect dependencies': function () {
 		var def;
 		def = generateDefine('foo', ['bar', 'baz'], '{}');
-		assert.equals(['bar', 'baz'], captureAmdArgs(def).named[0].depsList, 'named module');
+		assert.equals(['bar', 'baz'], captureDefines(def).named[0].depsList, 'named module');
 		def = generateDefine(null, ['bar', 'baz'], '{}');
-		assert.equals(['bar', 'baz'], captureAmdArgs(def).anon.depsList, 'anonymous module');
+		assert.equals(['bar', 'baz'], captureDefines(def).anon.depsList, 'anonymous module');
 	}
 
 });

--- a/test/lib/amd/factory.js
+++ b/test/lib/amd/factory.js
@@ -3,9 +3,9 @@ var assert = buster.assert;
 var refute = buster.refute;
 var fail = buster.assertions.fail;
 
-var amdFactory = require('../../lib/amdFactory');
+var amdFactory = require('../../../lib/amd/factory');
 
-buster.testCase('amdFactory', {
+buster.testCase('rave/lib/amd/factory', {
 
 	'// test this': function () {
 		assert(false);

--- a/test/lib/captureAmdDefines.js
+++ b/test/lib/captureAmdDefines.js
@@ -3,14 +3,14 @@ var assert = buster.assert;
 var refute = buster.refute;
 var fail = buster.assertions.fail;
 
-var captureAmdArgs = require('../../lib/captureAmdArgs');
+var captureAmdArgs = require('../../lib/captureAmdDefines');
 
 var nameOptions = { '': 1, 'name': 1 };
 var depCounts = { 'none': 1, 0: 1, 1: 1, 3: 1 };
 var factoryOptions = { '""': 1, '{}': 1, 'function () {}': 1 };
 var depsList = [ 'dep1', 'dep2', 'dep3' ];
 
-buster.testCase('captureAmdArgs', {
+buster.testCase('captureAmdDefines', {
 
 	'should not fail on many variations of define()': function () {
 		for (var name in nameOptions) {
@@ -31,25 +31,25 @@ buster.testCase('captureAmdArgs', {
 	'should always return a factory': function () {
 		var def;
 		def = generateDefine(null, null, '{}');
-		assert.isFunction(captureAmdArgs(def).factory, 'factory is object');
+		assert.isFunction(captureAmdArgs(def).anon.factory, 'factory is object');
 		def = generateDefine(null, null, '"foo"');
-		assert.isFunction(captureAmdArgs(def).factory, 'factory is string');
+		assert.isFunction(captureAmdArgs(def).anon.factory, 'factory is string');
 		def = generateDefine(null, null, '/foo/g');
-		assert.isFunction(captureAmdArgs(def).factory, 'factory is RegExp');
+		assert.isFunction(captureAmdArgs(def).anon.factory, 'factory is RegExp');
 	},
 
 	'should detect a named module': function () {
 		var def;
 		def = generateDefine('foo', null, '{}');
-		assert.equals('foo', captureAmdArgs(def).name);
+		assert.equals('foo', captureAmdArgs(def).named[0].name);
 	},
 
 	'should detect dependencies': function () {
 		var def;
 		def = generateDefine('foo', ['bar', 'baz'], '{}');
-		assert.equals(['bar', 'baz'], captureAmdArgs(def).depsList, 'named module');
+		assert.equals(['bar', 'baz'], captureAmdArgs(def).named[0].depsList, 'named module');
 		def = generateDefine(null, ['bar', 'baz'], '{}');
-		assert.equals(['bar', 'baz'], captureAmdArgs(def).depsList, 'anonymous module');
+		assert.equals(['bar', 'baz'], captureAmdArgs(def).anon.depsList, 'anonymous module');
 	}
 
 });


### PR DESCRIPTION
This would be an attempt at a super simple build -- a proof of concept, really.  The term "quick and dirty" is not beyond the lexicon that might be used during this attempt. :)  What this POC will prove:
- Rave can be used to load bundled modules and resources (js, css, html, etc.).
- Rave can reduce and/or eliminate build-time configuration.
- Rave can automate tasks necessary to switch between [responsive and built modes](https://github.com/RaveJS/rave/blob/master/docs/developing.md#building-your-app)
- Devs can install (and third-party authors can create) rave extensions to allow different build strategies.

After some discussion with @briancavalier, we decided that it would be easiest to create an ES5 bundle in the first attempt.  In other words, create an AMD or browserify bundle.  TBH, both browserify and AMD are far from ideal, but would be way easier than attempting an ES6-ish option at this point.  

Given my extensive experience with cram.js and AMD -- as well as some recent problems (#52) and my total lack of knowledge of browserify bundles -- I decided to try AMD first.  I suspect I'll be much more productive with the stuff I know intimately.  If attempts via cram go badly, I'll research our options with browserify asap.  

The first commit in this PR is (part 1 of 2) that will allow AMD bundles to be loaded.  (This is functionality we may have had to write anyways and is relatively easy to implement in the AMD-specific modules.)  

We also decided to try to leverage gulp because of its popularity and its use of streams.  

Still to do, but not necessarily in order:
- [x] Finish loading of AMD bundles.
- [ ] Create a gulp task to automate the creation of an AMD bundle via cram (or browserify).
- [ ] Create a gulp task to swap/rewrite boot.js.
- [ ] Create a gulp task to switch modes (responsive <--> built), which just runs the other gulp tasks.
- [ ] Bundle text, css, and json via a new cram plugin that maps extensions to text, css, and json cram plugins.
- [ ] Extract the build-related code out of rave and put it into a new rave extension repo (e.g. rave-build-cram or rave-build-browserify).  (Users will `npm install` these extensions.)
  - [ ] Replace with debug code that instructs the user how to find and install a rave-build-\* extension.
  - [ ] Refactor any "quick and dirty" code, ensure test coverage, etc.

Possible follow-on tasks, probably not in this PR, but here for discussion:
- Create a gulp file task rewrites index.html, rather than swaps boot.js.
- Create ES6-ish rave-build-\* extensions. 
- Allow multiple rave-build-\* extensions to co-exist in the same repo, allowing parts of one extension to be overridden by the other extensions.

I'll be updating this description from time to time as tasks are clarified, added, or removed.  Comments welcome, as usual.
