### PR TITLE
Rave should default to "debug mode" except for production.

### DIFF
--- a/auto.js
+++ b/auto.js
@@ -7,7 +7,10 @@ var normalizeCjs = require('./pipeline/normalizeCjs');
 var locateAsIs = require('./pipeline/locateAsIs');
 var fetchAsText = require('./pipeline/fetchAsText');
 var translateAsIs = require('./pipeline/translateAsIs');
-var instantiateJs = require('./pipeline/instantiateJs');
+var instantiateNode = require('./pipeline/instantiateNode');
+var instantiateAmd = require('./pipeline/instantiateAmd');
+var instantiateScript = require('./pipeline/instantiateScript');
+var instantiateJs = require('./lib/debug/instantiateJs');
 var beget = require('./lib/beget');
 var path = require('./lib/path');
 var pkg = require('./lib/package');
@@ -20,6 +23,12 @@ module.exports = {
 };
 
 var defaultMeta = 'bower.json,package.json';
+
+var instantiators = {
+	amd: instantiateAmd,
+	node: instantiateNode,
+	globals: instantiateScript
+};
 
 function autoConfigure (context) {
 	var urls, applyLoaderHooks;
@@ -89,7 +98,7 @@ function configureLoader (context) {
 		locate: locateAsIs,
 		fetch: fetchAsText,
 		translate: translateAsIs,
-		instantiate: instantiateJs
+		instantiate: instantiateJs(getInstantiator)
 	};
 	var overrides = fromMetadata(baseHooks, context);
 	context.load.overrides = overrides;
@@ -98,6 +107,10 @@ function configureLoader (context) {
 		context.loader[name] = hooks[name];
 	}
 	return Promise.resolve(context);
+}
+
+function getInstantiator (moduleType) {
+	return instantiators[moduleType];
 }
 
 function gatherExtensions (context) {

--- a/auto.js
+++ b/auto.js
@@ -3,6 +3,11 @@
 /** @author John Hann */
 var metadata = require('./lib/metadata');
 var fromMetadata = require('./lib/hooksFromMetadata');
+var normalizeCjs = require('./pipeline/normalizeCjs');
+var locateAsIs = require('./pipeline/locateAsIs');
+var fetchAsText = require('./pipeline/fetchAsText');
+var translateAsIs = require('./pipeline/translateAsIs');
+var instantiateJs = require('./pipeline/instantiateJs');
 var beget = require('./lib/beget');
 var path = require('./lib/path');
 var pkg = require('./lib/package');
@@ -79,7 +84,14 @@ function gatherAppMetadata (context, metadatas) {
 }
 
 function configureLoader (context) {
-	var overrides = fromMetadata(context);
+	var hooks = {
+		normalize: normalizeCjs,
+		locate: locateAsIs,
+		fetch: fetchAsText,
+		translate: translateAsIs,
+		instantiate: instantiateJs
+	};
+	var overrides = fromMetadata(hooks, context);
 	context.load.overrides = overrides;
 	var hooks = override.hooks(context.load.nativeHooks, overrides);
 	for (var name in hooks) {

--- a/auto.js
+++ b/auto.js
@@ -8,8 +8,14 @@ var locateAsIs = require('./pipeline/locateAsIs');
 var fetchAsText = require('./pipeline/fetchAsText');
 var translateAsIs = require('./pipeline/translateAsIs');
 var instantiateNode = require('./pipeline/instantiateNode');
+var nodeFactory = require('./lib/node/factory');
+var nodeEval = require('./lib/debug/nodeEval');
 var instantiateAmd = require('./pipeline/instantiateAmd');
+var captureDefines = require('./lib/debug/captureDefines');
+var amdEval = require('./lib/debug/amdEval');
 var instantiateScript = require('./pipeline/instantiateScript');
+var scriptFactory = require('./lib/debug/scriptFactory');
+var scriptEval = require('./lib/debug/scriptEval');
 var instantiateJs = require('./lib/debug/instantiateJs');
 var beget = require('./lib/beget');
 var path = require('./lib/path');
@@ -25,9 +31,9 @@ module.exports = {
 var defaultMeta = 'bower.json,package.json';
 
 var instantiators = {
-	amd: instantiateAmd,
-	node: instantiateNode,
-	globals: instantiateScript
+	amd: instantiateAmd(captureDefines(amdEval)),
+	node: instantiateNode(nodeFactory(nodeEval)),
+	globals: instantiateScript(scriptFactory(scriptEval))
 };
 
 function autoConfigure (context) {

--- a/auto.js
+++ b/auto.js
@@ -84,14 +84,14 @@ function gatherAppMetadata (context, metadatas) {
 }
 
 function configureLoader (context) {
-	var hooks = {
+	var baseHooks = {
 		normalize: normalizeCjs,
 		locate: locateAsIs,
 		fetch: fetchAsText,
 		translate: translateAsIs,
 		instantiate: instantiateJs
 	};
-	var overrides = fromMetadata(hooks, context);
+	var overrides = fromMetadata(baseHooks, context);
 	context.load.overrides = overrides;
 	var hooks = override.hooks(context.load.nativeHooks, overrides);
 	for (var name in hooks) {

--- a/debug.js
+++ b/debug.js
@@ -3,7 +3,10 @@
 /** @author John Hann */
 var auto = require('./auto');
 var uid = require('./lib/uid');
-//var override = require('./load/override');
+var amdEval = require('./lib/debug/amdEval');
+var nodeEval = require('./lib/debug/nodeEval');
+var scriptEval = require('./lib/debug/scriptEval');
+var es5Transform = require('./lib/es5Transform');
 var metadata = require('./lib/metadata');
 
 module.exports = {
@@ -104,6 +107,12 @@ function startDebug (context) {
 
 		console.log(message);
 	};
+
+	// override code evaluator modules with debuggable versions
+	context.loader.set('rave/lib/amd/eval', new Module(es5Transform.toLoader(amdEval)));
+	context.loader.set('rave/lib/node/eval', new Module(es5Transform.toLoader(nodeEval)));
+	context.loader.set('rave/lib/script/eval', new Module(es5Transform.toLoader(scriptEval)));
+
 
 	var applyHooks = auto.applyLoaderHooks;
 	auto.applyLoaderHooks = function (context, extensions) {

--- a/debug.js
+++ b/debug.js
@@ -3,9 +3,6 @@
 /** @author John Hann */
 var auto = require('./auto');
 var uid = require('./lib/uid');
-var amdEval = require('./lib/debug/amdEval');
-var nodeEval = require('./lib/debug/nodeEval');
-var scriptEval = require('./lib/debug/scriptEval');
 var es5Transform = require('./lib/es5Transform');
 var metadata = require('./lib/metadata');
 
@@ -107,12 +104,6 @@ function startDebug (context) {
 
 		console.log(message);
 	};
-
-	// override code evaluator modules with debuggable versions
-	context.loader.set('rave/lib/amd/eval', new Module(es5Transform.toLoader(amdEval)));
-	context.loader.set('rave/lib/node/eval', new Module(es5Transform.toLoader(nodeEval)));
-	context.loader.set('rave/lib/script/eval', new Module(es5Transform.toLoader(scriptEval)));
-
 
 	var applyHooks = auto.applyLoaderHooks;
 	auto.applyLoaderHooks = function (context, extensions) {

--- a/lib/amd/captureDefines.js
+++ b/lib/amd/captureDefines.js
@@ -5,73 +5,87 @@
 module.exports = captureDefines;
 
 function captureDefines (amdEval) {
+	var result;
+
+	define.amd = { jQuery: {} };
+
 	return function (load) {
-		var result, isAnon, capture;
-
-		result = { named: [] };
-
-		capture = function captureDefine () {
-			var args, def;
-
-			args = copy(arguments);
-
-			// last arg is always the factory (or a plain value)
-			def = { factory: ensureFactory(args.pop()) };
-
-			// if there are other args
-			if (args.length > 0) {
-				// get list of dependency module ids
-				def.depsList = args.pop();
-				// if this is a string, then there are no deps
-				if (typeof def.depsList === 'string') {
-					def.name = def.depsList;
-					delete def.depsList;
-				}
-				else {
-					def.name = args.pop() || null;
-				}
-				if (args.length > 0) {
-					throw new Error('Unparsable AMD define arguments ['
-						+ copy(arguments)
-						+ '] found in ' + load.name
-					);
-				}
-			}
-
-			if (!def.name) {
-				if (isAnon) {
-					throw new Error('Multiple anon defines in' + load.name);
-				}
-				isAnon = true;
-				result.anon = def;
-			}
-			else {
-				result.named.push(def);
-			}
-
-		};
-
-		// indicate we are AMD and we can handle the jqueries
-		capture.amd = { jQuery: {} };
-
-		amdEval(global, capture, load.source);
-
-		if (!result) {
-			throw new Error('AMD define not called in ' + load.name);
-		}
-
-		return result;
+		result = { named: [], isAnon: false, anon: void 0, called: false };
+		return capture(amdEval, define, load, result);
 	};
+
+	function define () {
+		return _define(result, arguments);
+	}
+}
+
+function capture (amdEval, define, load, result) {
+	try {
+		amdEval(global, define, load.source);
+	}
+	catch (ex) {
+		ex.message += ' in ' + load.name;
+		throw ex;
+	}
+	if (!result.called) {
+		throw new Error('AMD define not called in ' + load.name);
+	}
+	return result;
+}
+
+function _define (result, args) {
+	var len, def, arg, undef;
+
+	len = args.length;
+
+	result.called = true;
+
+	// last arg is always the factory (or a plain value)
+	def = {
+		factory: ensureFactory(args[--len]),
+		depsList: undef,
+		name: undef
+	};
+
+	// if there are more args
+	if (len) {
+		// get second-to-last arg
+		arg = args[--len];
+		if (typeof arg === 'string') {
+			def.name = arg;
+		}
+		else {
+			def.depsList = arg;
+		}
+	}
+
+	// if there are at least one more args and it's a string
+	if (len && typeof args[--len] === 'string') {
+		def.name = args[len];
+	}
+
+	// if we didn't consume exactly the right number of args
+	if (len !== 0) {
+		throw new Error('Unparsable AMD define arguments ['
+			+ Array.prototype.slice.call(args) +
+			']'
+		);
+	}
+
+	if (!def.name) {
+		if (result.isAnon) {
+			throw new Error('Multiple anon defines');
+		}
+		result.isAnon = true;
+		result.anon = def;
+	}
+	else {
+		result.named.push(def);
+	}
 }
 
 function ensureFactory (thing) {
 	return typeof thing === 'function'
 		? thing
 		: function () { return thing; }
-}
-
-var slice = Array.prototype.slice;
-
-function copy (thing) {
-	return slice.call(thing);
 }

--- a/lib/amd/captureDefines.js
+++ b/lib/amd/captureDefines.js
@@ -50,8 +50,6 @@ function captureDefines (source) {
 	// indicate we are AMD and we can handle the jqueries
 	capture.amd = { jQuery: {} };
 
-	// Note: V8 intermittently fails if we embed eval() in new Function()
-	// and source has "use strict" in it
 	amdEval(global, capture, source);
 
 	if (!result) {

--- a/lib/amd/captureDefines.js
+++ b/lib/amd/captureDefines.js
@@ -2,61 +2,66 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var amdEval = require('./eval');
-
 module.exports = captureDefines;
 
-function captureDefines (source) {
-	var result, isAnon, capture;
+function captureDefines (amdEval) {
+	return function (load) {
+		var result, isAnon, capture;
 
-	result = { named: [] };
+		result = { named: [] };
 
-	capture = function captureDefine () {
-		var args, def;
+		capture = function captureDefine () {
+			var args, def;
 
-		args = copy(arguments);
+			args = copy(arguments);
 
-		// last arg is always the factory (or a plain value)
-		def = { factory: ensureFactory(args.pop()) };
+			// last arg is always the factory (or a plain value)
+			def = { factory: ensureFactory(args.pop()) };
 
-		// if there are other args
-		if (args.length > 0) {
-			// get list of dependency module ids
-			def.depsList = args.pop();
-			// if this is a string, then there are no deps
-			if (typeof def.depsList === 'string') {
-				def.name = def.depsList;
-				delete def.depsList;
+			// if there are other args
+			if (args.length > 0) {
+				// get list of dependency module ids
+				def.depsList = args.pop();
+				// if this is a string, then there are no deps
+				if (typeof def.depsList === 'string') {
+					def.name = def.depsList;
+					delete def.depsList;
+				}
+				else {
+					def.name = args.pop() || null;
+				}
+				if (args.length > 0) {
+					throw new Error('Unparsable AMD define arguments ['
+						+ copy(arguments)
+						+ '] found in ' + load.name
+					);
+				}
+			}
+
+			if (!def.name) {
+				if (isAnon) {
+					throw new Error('Multiple anon defines in' + load.name);
+				}
+				isAnon = true;
+				result.anon = def;
 			}
 			else {
-				def.name = args.pop() || null;
+				result.named.push(def);
 			}
-			if (args.length > 0) {
-				throw new Error('Unparsable AMD define arguments: ', copy(arguments));
-			}
+
+		};
+
+		// indicate we are AMD and we can handle the jqueries
+		capture.amd = { jQuery: {} };
+
+		amdEval(global, capture, load.source);
+
+		if (!result) {
+			throw new Error('AMD define not called in ' + load.name);
 		}
 
-		if (!def.name) {
-			if (isAnon) throw new Error('Multiple anonymous defines.');
-			isAnon = true;
-			result.anon = def;
-		}
-		else {
-			result.named.push(def);
-		}
-
+		return result;
 	};
-
-	// indicate we are AMD and we can handle the jqueries
-	capture.amd = { jQuery: {} };
-
-	amdEval(global, capture, source);
-
-	if (!result) {
-		throw new Error('AMD define not called.');
-	}
-
-	return result;
 }
 
 function ensureFactory (thing) {
@@ -65,6 +70,8 @@ function ensureFactory (thing) {
 		: function () { return thing; }
 }
 
+var slice = Array.prototype.slice;
+
 function copy (thing) {
-	return Array.prototype.slice.call(thing);
+	return slice.call(thing);
 }

--- a/lib/debug/amdEval.js
+++ b/lib/debug/amdEval.js
@@ -1,0 +1,25 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var injectScript = require('./injectScript');
+
+module.exports = amdEval;
+
+var noDefine = {};
+
+function amdEval (global, define, source) {
+	var prevDefine = 'define' in global ? global.define : noDefine;
+	global.define = define;
+	try {
+		injectScript(source);
+	}
+	finally {
+		if (global.define === noDefine) {
+			delete global.define;
+		}
+		else {
+			global.define = prevDefine;
+		}
+	}
+}

--- a/lib/debug/captureDefines.js
+++ b/lib/debug/captureDefines.js
@@ -1,0 +1,17 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var addSourceUrl = require('../addSourceUrl');
+var origCaptureDefines = require('../amd/captureDefines');
+
+module.exports = captureDefines;
+
+function captureDefines (amdEval) {
+	return function (load) {
+		return origCaptureDefines(_eval)(load);
+		function _eval (global, define, source) {
+			return amdEval(global, define, addSourceUrl(load.address, source));
+		}
+	};
+}

--- a/lib/debug/injectScript.js
+++ b/lib/debug/injectScript.js
@@ -1,0 +1,32 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+module.exports = injectScript;
+
+var injectSource = function (el, source) {
+	// got this sniff from Stoyan Stefanov
+	// (http://www.phpied.com/dynamic-script-and-style-elements-in-ie/)
+	injectSource = 'text' in el ? setText : appendChild;
+	injectSource(el, source);
+};
+
+var doc = document;
+var head = doc && (doc['head'] || doc.getElementsByTagName('head')[0]);
+var insertBeforeEl = head && head.getElementsByTagName('base')[0] || null;
+
+function injectScript (source) {
+	var el = doc.createElement('script');
+	injectSource(el, source);
+	el.charset = 'utf-8';
+	head.insertBefore(el, insertBeforeEl);
+	head.removeChild(el);
+}
+
+function setText (el, source) {
+	el.text = source;
+}
+
+function appendChild (el, source) {
+	el.appendChild(doc.createTextNode(source));
+}

--- a/lib/debug/instantiateJS.js
+++ b/lib/debug/instantiateJS.js
@@ -2,14 +2,16 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var metadata = require('../lib/metadata');
-var moduleType = metadata.moduleType;
+var moduleType = require('./moduleType');
 
 module.exports = instantiateJs;
 
 function instantiateJs (instantiator) {
 	return function (load) {
-		var pkg = metadata.findPackage(load.metadata.rave.packages, load.name);
-		return instantiator(moduleType(pkg) || 'globals')(load);
+		var instantiate = instantiator(moduleType(load));
+		if (!instantiate) {
+			throw new Error('No instantiator found for ' + load.name);
+		}
+		return instantiate(load);
 	};
 }

--- a/lib/debug/moduleType.js
+++ b/lib/debug/moduleType.js
@@ -1,0 +1,35 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var metadata = require('../metadata');
+var findEs5ModuleTypes = require('../find/es5ModuleTypes');
+
+module.exports = moduleType;
+
+function moduleType (load) {
+	var pkg, type;
+
+	pkg = metadata.findPackage(load.metadata.rave.packages, load.name);
+	type = metadata.moduleType(pkg);
+
+	if (type) {
+		return type;
+	}
+	else {
+		pkg.moduleType = guessModuleType(load) || ['globals']; // fix package
+		return metadata.moduleType(pkg); // try again :)
+	}
+}
+
+function guessModuleType (load) {
+	try {
+		var evidence = findEs5ModuleTypes(load.source, true);
+		return evidence.isAmd && ['amd']
+			|| evidence.isCjs && ['node'];
+	}
+	catch (ex) {
+		ex.message += ' ' + load.name + ' ' + load.address;
+		throw ex;
+	}
+}

--- a/lib/debug/nodeEval.js
+++ b/lib/debug/nodeEval.js
@@ -1,0 +1,24 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var injectScript = require('./injectScript');
+
+module.exports = nodeEval;
+
+function nodeEval (global, require, exports, module, source) {
+	var script;
+	script = '__rave_node(function (require, exports, module, global) {'
+		+ source
+		+ '\n})';
+	global.__rave_node = __rave_node;
+	try {
+		injectScript(script);
+	}
+	finally {
+		delete global.__rave_node;
+	}
+	function __rave_node (factory) {
+		factory(require, exports, module, global);
+	}
+}

--- a/lib/debug/nodeFactory.js
+++ b/lib/debug/nodeFactory.js
@@ -1,0 +1,18 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var factory = require('../node/factory');
+var addSourceUrl = require('../addSourceUrl');
+
+module.exports = nodeFactory;
+
+function nodeFactory (nodeEval) {
+	return function (loader, load) {
+		return factory(debugEval)(loader, load);
+		function debugEval (global, require, exports, module, source) {
+			var debugSrc = addSourceUrl(load.address, source);
+			return nodeEval(global, require, exports, module, debugSrc);
+		}
+	};
+}

--- a/lib/debug/scriptEval.js
+++ b/lib/debug/scriptEval.js
@@ -6,6 +6,6 @@ var injectScript = require('./injectScript');
 
 module.exports = scriptEval;
 
-function scriptEval (global, define, source) {
+function scriptEval (source) {
 	injectScript(source);
 }

--- a/lib/debug/scriptEval.js
+++ b/lib/debug/scriptEval.js
@@ -1,0 +1,11 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var injectScript = require('./injectScript');
+
+module.exports = scriptEval;
+
+function scriptEval (global, define, source) {
+	injectScript(source);
+}

--- a/lib/debug/scriptFactory.js
+++ b/lib/debug/scriptFactory.js
@@ -5,15 +5,15 @@
 var factory = require('../script/factory');
 var addSourceUrl = require('../addSourceUrl');
 
-// re-export
 module.exports = scriptFactory;
 
 function scriptFactory (scriptEval) {
 	return function (loader, load) {
+		var address = load.address;
 		return factory(debugEval)(loader, load);
-		function debugEval (global, define, source) {
-			var debugSrc = addSourceUrl(load.address, source);
-			return scriptEval(global, define, debugSrc);
+		function debugEval (source) {
+			var debugSrc = addSourceUrl(address, source);
+			scriptEval(debugSrc);
 		}
 	};
 }

--- a/lib/debug/scriptFactory.js
+++ b/lib/debug/scriptFactory.js
@@ -1,0 +1,8 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var factory = require('../script/factory');
+
+// re-export
+module.exports = factory;

--- a/lib/debug/scriptFactory.js
+++ b/lib/debug/scriptFactory.js
@@ -3,6 +3,17 @@
 /** @author John Hann */
 
 var factory = require('../script/factory');
+var addSourceUrl = require('../addSourceUrl');
 
 // re-export
-module.exports = factory;
+module.exports = scriptFactory;
+
+function scriptFactory (scriptEval) {
+	return function (loader, load) {
+		return factory(debugEval)(loader, load);
+		function debugEval (global, define, source) {
+			var debugSrc = addSourceUrl(load.address, source);
+			return scriptEval(global, define, debugSrc);
+		}
+	};
+}

--- a/lib/hooksFromMetadata.js
+++ b/lib/hooksFromMetadata.js
@@ -2,22 +2,14 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 var parseUid = require('./uid').parse;
-var metadata = require('./metadata');
-var normalizeCjs = require('../pipeline/normalizeCjs');
 var createNormalizer = require('./createNormalizer');
 var createVersionedIdTransform = require('./createVersionedIdTransform');
 var createPackageMapper = require('./createPackageMapper');
 var locatePackage = require('../pipeline/locatePackage');
-var fetchAsText = require('../pipeline/fetchAsText');
-var translateAsIs = require('../pipeline/translateAsIs');
-var instantiateNode = require('../pipeline/instantiateNode');
-var instantiateAmd = require('../pipeline/instantiateAmd');
-var instantiateScript = require('../pipeline/instantiateScript');
-var findEs5ModuleTypes = require('./find/es5ModuleTypes');
 
 module.exports = hooksFromMetadata;
 
-function hooksFromMetadata (context) {
+function hooksFromMetadata (hooks, context) {
 	var metadataOverride;
 
 	metadataOverride = {
@@ -26,12 +18,12 @@ function hooksFromMetadata (context) {
 			normalize: createNormalizer(
 				createVersionedIdTransform(context),
 				createPackageMapper(context),
-				normalizeCjs
+				hooks.normalize
 			),
-			locate: withContext(context, locatePackage),
-			fetch: fetchAsText,
-			translate: translateAsIs,
-			instantiate: instantiate
+			locate: withContext(context, locatePackage), // hooks.locate not used
+			fetch: hooks.fetch,
+			translate: hooks.translate,
+			instantiate: hooks.instantiate
 		}
 	};
 
@@ -50,43 +42,4 @@ function withContext (context, func) {
 		load.metadata.rave = context;
 		return func.call(this, load);
 	};
-}
-
-function instantiate (load) {
-	var pkg, moduleType;
-
-	pkg = metadata.findPackage(load.metadata.rave.packages, load.name);
-	moduleType = pkg.moduleType;
-
-	// prefer amd-formatted modules since they use less string manip
-	if (hasModuleType(moduleType, 'amd')) {
-		return instantiateAmd(load);
-	}
-	else if (hasModuleType(moduleType, 'node')) {
-		return instantiateNode(load);
-	}
-	else if (hasModuleType(moduleType, 'globals')) {
-		return instantiateScript(load);
-	}
-	else {
-		moduleType = guessModuleType(load);
-		pkg.moduleType = moduleType || [ 'globals' ]; // fix package
-		return instantiate(load); // try again :)
-	}
-}
-
-function hasModuleType (moduleType, type) {
-	return moduleType && moduleType.indexOf(type) >= 0;
-}
-
-function guessModuleType (load) {
-	try {
-		var evidence = findEs5ModuleTypes(load.source, true);
-		return evidence.isAmd && [ 'amd' ]
-			|| evidence.isCjs && [ 'node' ];
-	}
-	catch (ex) {
-		ex.message += ' ' + load.name + ' ' + load.address;
-		throw ex;
-	}
 }

--- a/lib/json/eval.js
+++ b/lib/json/eval.js
@@ -1,0 +1,9 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+module.exports = jsonEval;
+
+function jsonEval (source) {
+	return eval(source);
+}

--- a/lib/json/eval.js
+++ b/lib/json/eval.js
@@ -5,5 +5,5 @@
 module.exports = jsonEval;
 
 function jsonEval (source) {
-	return eval(source);
+	return eval('(' + source + ')');
 }

--- a/lib/json/factory.js
+++ b/lib/json/factory.js
@@ -1,0 +1,12 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var es5Transform = require('../es5Transform');
+var jsonEval = require('./eval');
+
+module.exports = jsonFactory;
+
+function jsonFactory (loader, load) {
+	return es5Transform.toLoader(jsonEval(load.source));
+}

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -7,7 +7,8 @@ var beget = require('./beget');
 
 module.exports = {
 	findPackage: findPackageDescriptor,
-	findDepPackage: findDependentPackage
+	findDepPackage: findDependentPackage,
+	moduleType: moduleType
 };
 
 function findPackageDescriptor (descriptors, fromModule) {
@@ -35,4 +36,25 @@ function findDependentPackage (descriptors, fromPkg, depName) {
 		depPkgUid = fromPkg ? fromPkg.deps[pkgName] : pkgName;
 		return depPkgUid && descriptors[depPkgUid];
 	}
+}
+
+function moduleType (descriptor) {
+	var moduleTypes;
+
+	moduleTypes = descriptor.moduleType;
+
+	if (hasModuleType(moduleTypes, 'amd')) {
+		return 'amd';
+	}
+	else if (hasModuleType(moduleTypes, 'node')) {
+		return 'node';
+	}
+	else if (hasModuleType(moduleTypes, 'globals')) {
+		return 'globals';
+	}
+
+}
+
+function hasModuleType (moduleTypes, type) {
+	return moduleTypes && moduleTypes.indexOf(type) >= 0;
 }

--- a/lib/node/factory.js
+++ b/lib/node/factory.js
@@ -1,15 +1,12 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
+
+var es5Transform = require('../es5Transform');
+var createRequire = require('../createRequire');
+var nodeEval = require('./eval');
+
 module.exports = nodeFactory;
-
-var es5Transform = require('./es5Transform');
-var createRequire = require('./createRequire');
-var nodeEval = require('./node/eval');
-
-var _global;
-
-_global = typeof global !== 'undefined' ? global : window;
 
 function nodeFactory (loader, load) {
 	var name, source, exports, module, require;
@@ -21,8 +18,7 @@ function nodeFactory (loader, load) {
 	require = createRequire(loader, name);
 
 	return function () {
-		// TODO: use loader.global when es6-module-loader implements it
-		nodeEval(_global, require, exports, module, source);
+		nodeEval(global, require, exports, module, source);
 		// figure out what author intended to export
 		return exports === module.exports
 			? exports // a set of named exports

--- a/lib/node/factory.js
+++ b/lib/node/factory.js
@@ -4,7 +4,6 @@
 
 var es5Transform = require('../es5Transform');
 var createRequire = require('../createRequire');
-var nodeEval = require('./eval');
 
 module.exports = nodeFactory;
 

--- a/lib/node/factory.js
+++ b/lib/node/factory.js
@@ -8,20 +8,22 @@ var nodeEval = require('./eval');
 
 module.exports = nodeFactory;
 
-function nodeFactory (loader, load) {
-	var name, source, exports, module, require;
+function nodeFactory (nodeEval) {
+	return function (loader, load) {
+		var name, source, exports, module, require;
 
-	name = load.name;
-	source = load.source;
-	exports = {};
-	module = { id: name, uri: load.address, exports: exports };
-	require = createRequire(loader, name);
+		name = load.name;
+		source = load.source;
+		exports = {};
+		module = { id: name, uri: load.address, exports: exports };
+		require = createRequire(loader, name);
 
-	return function () {
-		nodeEval(global, require, exports, module, source);
-		// figure out what author intended to export
-		return exports === module.exports
-			? exports // a set of named exports
-			: es5Transform.toLoader(module.exports); // a single default export
+		return function () {
+			nodeEval(global, require, exports, module, source);
+			// figure out what author intended to export
+			return exports === module.exports
+				? exports // a set of named exports
+				: es5Transform.toLoader(module.exports); // a single default export
+		};
 	};
 }

--- a/lib/script/eval.js
+++ b/lib/script/eval.js
@@ -2,8 +2,8 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-module.exports = globalEval;
+module.exports = scriptEval;
 
-function globalEval (source) {
+function scriptEval (source) {
 	new Function(source)();
 }

--- a/lib/script/factory.js
+++ b/lib/script/factory.js
@@ -2,12 +2,12 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var globalEval = require('./script/eval');
+var scriptEval = require('./eval');
 
-module.exports = globalFactory;
+module.exports = scriptFactory;
 
-function globalFactory (loader, load) {
+function scriptFactory (loader, load) {
 	return function () {
-		globalEval(load.source);
+		scriptEval(load.source);
 	};
 }

--- a/lib/script/factory.js
+++ b/lib/script/factory.js
@@ -2,12 +2,12 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var scriptEval = require('./eval');
-
 module.exports = scriptFactory;
 
-function scriptFactory (loader, load) {
-	return function () {
-		scriptEval(load.source);
+function scriptFactory (scriptEval) {
+	return function (loader, load) {
+		return function () {
+			scriptEval(load.source);
+		};
 	};
 }

--- a/lib/script/factory.js
+++ b/lib/script/factory.js
@@ -6,8 +6,10 @@ module.exports = scriptFactory;
 
 function scriptFactory (scriptEval) {
 	return function (loader, load) {
-		return function () {
-			scriptEval(load.source);
-		};
+		return create(scriptEval, load.source);
 	};
+}
+
+function create (scriptEval, source) {
+	return function () { scriptEval(source); };
 }

--- a/pipeline/instantiateAmd.js
+++ b/pipeline/instantiateAmd.js
@@ -4,7 +4,6 @@
 var findRequires = require('../lib/find/requires');
 var captureDefines = require('../lib/amd/captureDefines');
 var amdFactory = require('../lib/amd/factory');
-var addSourceUrl = require('../lib/addSourceUrl');
 var processBundle = require('../lib/amd/bundle').process;
 
 module.exports = instantiateAmd;
@@ -15,11 +14,6 @@ function instantiateAmd (load) {
 	var loader, defines, mainDefine, arity, factory, deps, i;
 
 	loader = load.metadata.rave.loader;
-
-	// if debugging, add sourceURL
-	if (load.metadata.rave.debug) {
-		load.source = addSourceUrl(load.address, load.source);
-	}
 
 	// the surest way to capture the many define() variations is to run it
 	defines = captureOrThrow(load);

--- a/pipeline/instantiateAmd.js
+++ b/pipeline/instantiateAmd.js
@@ -1,6 +1,7 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
+
 var findRequires = require('../lib/find/requires');
 var captureDefines = require('../lib/amd/captureDefines');
 var amdFactory = require('../lib/amd/factory');
@@ -10,57 +11,48 @@ module.exports = instantiateAmd;
 
 var scopedVars = ['require', 'exports', 'module'];
 
-function instantiateAmd (load) {
-	var loader, defines, mainDefine, arity, factory, deps, i;
+function instantiateAmd (captureDefines) {
+	return function (load) {
+		var loader, defines, mainDefine, arity, factory, deps, i;
 
-	loader = load.metadata.rave.loader;
+		loader = load.metadata.rave.loader;
 
-	// the surest way to capture the many define() variations is to run it
-	defines = captureOrThrow(load);
+		// the surest way to capture the many define() variations is to run it
+		defines = captureDefines(load);
 
-	if (defines.named.length <= 1) {
-		mainDefine = defines.anon || defines.named.pop()
-	}
-	else {
-		mainDefine = processBundle(load, defines.named);
-	}
-
-	arity = mainDefine.factory.length;
-
-	// copy deps so we can remove items below!
-	deps = mainDefine.depsList ? mainDefine.depsList.slice() : [];
-
-	if (mainDefine.depsList == null && arity > 0) {
-		mainDefine.requires = findOrThrow(load, mainDefine.factory.toString());
-		mainDefine.depsList = scopedVars.slice(0, arity);
-		deps = deps.concat(mainDefine.requires);
-	}
-
-	factory = amdFactory(loader, mainDefine, load);
-
-	// remove "require", "exports", "module" from loader deps
-	for (i = deps.length - 1; i >= 0; i--) {
-		if (scopedVars.indexOf(deps[i]) >= 0) {
-			deps.splice(i, 1);
+		if (defines.named.length <= 1) {
+			mainDefine = defines.anon || defines.named.pop()
 		}
-	}
-
-	return {
-		deps: deps,
-		execute: function () {
-			return new Module(factory.apply(loader, arguments));
+		else {
+			mainDefine = processBundle(load, defines.named);
 		}
-	};
-}
 
-function captureOrThrow (load) {
-	try {
-		return captureDefines(load.source);
-	}
-	catch (ex) {
-		ex.message = 'Error while parsing AMD: '
-			+ load.name + '. ' + ex.message;
-		throw ex;
+		arity = mainDefine.factory.length;
+
+		// copy deps so we can remove items below!
+		deps = mainDefine.depsList ? mainDefine.depsList.slice() : [];
+
+		if (mainDefine.depsList == null && arity > 0) {
+			mainDefine.requires = findOrThrow(load, mainDefine.factory.toString());
+			mainDefine.depsList = scopedVars.slice(0, arity);
+			deps = deps.concat(mainDefine.requires);
+		}
+
+		factory = amdFactory(loader, mainDefine, load);
+
+		// remove "require", "exports", "module" from loader deps
+		for (i = deps.length - 1; i >= 0; i--) {
+			if (scopedVars.indexOf(deps[i]) >= 0) {
+				deps.splice(i, 1);
+			}
+		}
+
+		return {
+			deps: deps,
+			execute: function () {
+				return new Module(factory.apply(loader, arguments));
+			}
+		};
 	}
 }
 

--- a/pipeline/instantiateJs.js
+++ b/pipeline/instantiateJs.js
@@ -1,0 +1,50 @@
+/** @license MIT License (c) copyright 2014 original authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var metadata = require('../lib/metadata');
+var instantiateNode = require('./instantiateNode');
+var instantiateAmd = require('./instantiateAmd');
+var instantiateScript = require('./instantiateScript');
+var findEs5ModuleTypes = require('../lib/find/es5ModuleTypes');
+
+module.exports = instantiateJs;
+
+function instantiateJs (load) {
+	var pkg, moduleType;
+
+	pkg = metadata.findPackage(load.metadata.rave.packages, load.name);
+	moduleType = pkg.moduleType;
+
+	// prefer amd-formatted modules since they use less string manip
+	if (hasModuleType(moduleType, 'amd')) {
+		return instantiateAmd(load);
+	}
+	else if (hasModuleType(moduleType, 'node')) {
+		return instantiateNode(load);
+	}
+	else if (hasModuleType(moduleType, 'globals')) {
+		return instantiateScript(load);
+	}
+	else {
+		moduleType = guessModuleType(load);
+		pkg.moduleType = moduleType || ['globals']; // fix package
+		return instantiateJs(load); // try again :)
+	}
+}
+
+function hasModuleType (moduleType, type) {
+	return moduleType && moduleType.indexOf(type) >= 0;
+}
+
+function guessModuleType (load) {
+	try {
+		var evidence = findEs5ModuleTypes(load.source, true);
+		return evidence.isAmd && ['amd']
+			|| evidence.isCjs && ['node'];
+	}
+	catch (ex) {
+		ex.message += ' ' + load.name + ' ' + load.address;
+		throw ex;
+	}
+}

--- a/pipeline/instantiateJson.js
+++ b/pipeline/instantiateJson.js
@@ -1,24 +1,15 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
-var es5Transform = require('../lib/es5Transform');
-var addSourceUrl = require('../lib/addSourceUrl');
+var jsonFactory = require('../lib/json/factory');
 
 module.exports = instantiateJson;
 
 function instantiateJson (load) {
-	var source;
-
-	source = '(' + load.source + ')';
-
-	// if debugging, add sourceURL
-	if (load.metadata.rave.debug) {
-		source = addSourceUrl(load.address, source);
-	}
-
+	var loader = load.metadata.rave.loader;
 	return {
 		execute: function () {
-			return new Module(es5Transform.toLoader(eval(source)));
+			return new Module(jsonFactory(loader, load));
 		}
 	};
 }

--- a/pipeline/instantiateNode.js
+++ b/pipeline/instantiateNode.js
@@ -2,8 +2,7 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 var findRequires = require('../lib/find/requires');
-var nodeFactory = require('../lib/nodeFactory');
-var addSourceUrl = require('../lib/addSourceUrl');
+var nodeFactory = require('../lib/node/factory');
 
 module.exports = instantiateNode;
 
@@ -12,11 +11,6 @@ function instantiateNode (load) {
 
 	loader = load.metadata.rave.loader;
 	deps = findOrThrow(load);
-
-	// if debugging, add sourceURL
-	if (load.metadata.rave.debug) {
-		load.source = addSourceUrl(load.address, load.source);
-	}
 
 	factory = nodeFactory(loader, load);
 

--- a/pipeline/instantiateNode.js
+++ b/pipeline/instantiateNode.js
@@ -2,24 +2,25 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 var findRequires = require('../lib/find/requires');
-var nodeFactory = require('../lib/node/factory');
 
 module.exports = instantiateNode;
 
-function instantiateNode (load) {
-	var loader, deps, factory;
+function instantiateNode (nodeFactory) {
+	return function (load) {
+		var loader, deps, factory;
 
-	loader = load.metadata.rave.loader;
-	deps = findOrThrow(load);
+		loader = load.metadata.rave.loader;
+		deps = findOrThrow(load);
 
-	factory = nodeFactory(loader, load);
+		factory = nodeFactory(loader, load);
 
-	return {
-		deps: deps,
-		execute: function () {
-			return new Module(factory.apply(this, arguments));
-		}
-	};
+		return {
+			deps: deps,
+			execute: function () {
+				return new Module(factory.apply(this, arguments));
+			}
+		};
+	}
 }
 
 function findOrThrow (load) {

--- a/pipeline/instantiateScript.js
+++ b/pipeline/instantiateScript.js
@@ -3,29 +3,29 @@
 /** @author John Hann */
 module.exports = instantiateScript;
 
-var scriptFactory = require('../lib/script/factory');
 var metadata = require('../lib/metadata');
 var path = require('../lib/path');
 
-function instantiateScript (load) {
-	var packages, pkg, deps;
+function instantiateScript (scriptFactory) {
+	return function (load) {
+		var packages, pkg, deps;
 
-	// find dependencies
-	packages = load.metadata.rave.packages;
-	pkg = metadata.findPackage(packages, load.name);
-	if (pkg && pkg.deps) {
-		deps = pkgMains(packages, pkg.deps)
-	}
-
-	var factory = scriptFactory(this, load);
-	return {
-		deps: deps,
-		execute: function () {
-			factory();
-			return new Module({});
+		// find dependencies
+		packages = load.metadata.rave.packages;
+		pkg = metadata.findPackage(packages, load.name);
+		if (pkg && pkg.deps) {
+			deps = pkgMains(packages, pkg.deps)
 		}
-	};
 
+		var factory = scriptFactory(this, load);
+		return {
+			deps: deps,
+			execute: function () {
+				factory();
+				return new Module({});
+			}
+		};
+	}
 }
 
 

--- a/pipeline/instantiateScript.js
+++ b/pipeline/instantiateScript.js
@@ -3,18 +3,12 @@
 /** @author John Hann */
 module.exports = instantiateScript;
 
-var globalFactory = require('../lib/globalFactory');
-var addSourceUrl = require('../lib/addSourceUrl');
+var scriptFactory = require('../lib/script/factory');
 var metadata = require('../lib/metadata');
 var path = require('../lib/path');
 
 function instantiateScript (load) {
 	var packages, pkg, deps;
-
-	// if debugging, add sourceURL
-	if (load.metadata.rave.debug) {
-		load.source = addSourceUrl(load.address, load.source);
-	}
 
 	// find dependencies
 	packages = load.metadata.rave.packages;
@@ -23,7 +17,7 @@ function instantiateScript (load) {
 		deps = pkgMains(packages, pkg.deps)
 	}
 
-	var factory = globalFactory(this, load);
+	var factory = scriptFactory(this, load);
 	return {
 		deps: deps,
 		execute: function () {

--- a/rave.js
+++ b/rave.js
@@ -2308,6 +2308,7 @@ rave.baseUrl = document
 	: __dirname;
 
 context = (document ? mergeBrowserOptions : mergeNodeOptions)({
+	debug: true,
 	raveMain: defaultMain,
 	raveScript: rave.scriptUrl,
 	baseUrl: rave.baseUrl,
@@ -2448,6 +2449,15 @@ function toLoader (value) {
 
 function locateAsIs (load) {
 	return load.name;
+}
+
+});
+
+
+;define('rave/pipeline/translateAsIs', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = translateAsIs;
+
+function translateAsIs (load) {
+	return load.source;
 }
 
 });
@@ -2595,15 +2605,6 @@ function splitDirAndFile (url) {
 });
 
 
-;define('rave/pipeline/translateAsIs', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = translateAsIs;
-
-function translateAsIs (load) {
-	return load.source;
-}
-
-});
-
-
 ;define('rave/lib/beget', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = beget;
 
 function Begetter () {}
@@ -2613,18 +2614,6 @@ function beget (base) {
 	obj = new Begetter();
 	Begetter.prototype = null;
 	return obj;
-}
-
-});
-
-
-;define('rave/lib/addSourceUrl', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = addSourceUrl;
-
-function addSourceUrl (url, source) {
-	return source
-		+ '\n//# sourceURL='
-		+ encodeURI(url)
-		+ '\n';
 }
 
 });
@@ -2652,6 +2641,18 @@ function fetchText (url, callback, errback) {
 		}
 	};
 	xhr.send(null);
+}
+
+});
+
+
+;define('rave/lib/addSourceUrl', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = addSourceUrl;
+
+function addSourceUrl (url, source) {
+	return source
+		+ '\n//# sourceURL='
+		+ encodeURI(url)
+		+ '\n';
 }
 
 });
@@ -2814,18 +2815,6 @@ function getName (uid) {
 });
 
 
-;define('rave/lib/node/eval', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = nodeEval;
-
-function nodeEval (global, require, exports, module, source) {
-	// Note: V8 intermittently fails if we embed eval() in new Function()
-	// and source has "use strict" in it
-	new Function ('require', 'exports', 'module', 'global', source)
-		.call(exports, require, exports, module, global, source);
-}
-
-});
-
-
 ;define('rave/lib/find/createCodeFinder', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = createCodeFinder;
 
 // Export private functions for testing
@@ -2932,6 +2921,18 @@ function skipTo (source, rx, index) {
 
 function composeRx (rx1, rx2, flags) {
 	return new RegExp(rx1.source + '|' + rx2.source, flags);
+}
+
+});
+
+
+;define('rave/lib/node/eval', ['require', 'exports', 'module'], function (require, exports, module, define) {module.exports = nodeEval;
+
+function nodeEval (global, require, exports, module, source) {
+	// Note: V8 intermittently fails if we embed eval() in new Function()
+	// and source has "use strict" in it
+	new Function ('require', 'exports', 'module', 'global', source)
+		.call(exports, require, exports, module, global, source);
 }
 
 });

--- a/rave.js
+++ b/rave.js
@@ -2282,15 +2282,14 @@ if (typeof exports !== 'undefined') {
 /** @author Brian Cavalier */
 /** @author John Hann */
 (function (exports, global) {
-var rave, document, defaultMain, debugMain, hooksName,
+var rave, doc, defaultMain, hooksName,
 	context, loader, define;
 
 rave = exports || {};
 
-document = global.document;
+doc = global.document;
 
-defaultMain = 'rave/auto';
-debugMain = 'rave/debug';
+defaultMain = 'rave/debug';
 hooksName = 'rave/src/hooks';
 
 // export testable functions
@@ -2303,11 +2302,11 @@ rave.simpleDefine = simpleDefine;
 // initialize
 rave.scriptUrl = getCurrentScript();
 rave.scriptPath = getPathFromUrl(rave.scriptUrl);
-rave.baseUrl = document
+rave.baseUrl = doc
 	? getPathFromUrl(window.location.origin + window.location.pathname)
 	: __dirname;
 
-context = (document ? mergeBrowserOptions : mergeNodeOptions)({
+context = (doc ? mergeBrowserOptions : mergeNodeOptions)({
 	debug: true,
 	raveMain: defaultMain,
 	raveScript: rave.scriptUrl,
@@ -2322,11 +2321,6 @@ define.amd = {};
 function boot (context) {
 	var main = context.raveMain;
 	try {
-		// check if we should load debugMain instead
-		if (context.debug || context.raveDebug) {
-			// don't override main if user changed it with <html> attr
-			if (context.raveMain === defaultMain) context.raveMain = debugMain;
-		}
 		// apply hooks overrides to loader
 		var hooks = fromLoader(loader.get(hooksName));
 		// extend loader
@@ -2352,7 +2346,7 @@ function getCurrentScript () {
 	var stack, matches;
 
 	// HTML5 way
-	if (document && document.currentScript) return document.currentScript.src;
+	if (doc && doc.currentScript) return doc.currentScript.src;
 
 	// From https://gist.github.com/cphoover/6228063
 	// (Note: Ben Alman's shortcut doesn't work everywhere.)
@@ -2371,14 +2365,12 @@ function getPathFromUrl (url) {
 }
 
 function mergeBrowserOptions (context) {
-	var el = document.documentElement, i, attr, prop;
-	for (i = 0; i < el.attributes.length; i++) {
-		attr = el.attributes[i];
-		prop = attr.name.slice(5).replace(/(?:data)?-(.)/g, camelize);
-		if (prop) context[prop] = attr.value || true;
+	var el = doc.documentElement, i, attr, prop;
+	var meta = el.getAttribute('data-rave-meta');
+	if (meta) {
+		context.raveMeta = meta;
 	}
 	return context;
-	function camelize (m, l) { return l.toUpperCase();}
 }
 
 function mergeNodeOptions (context) {
@@ -2938,19 +2930,6 @@ function nodeEval (global, require, exports, module, source) {
 });
 
 
-;define('rave/pipeline/normalizeCjs', ['require', 'exports', 'module', 'rave/lib/path'], function (require, exports, module, $cram_r0, define) {var path = $cram_r0;
-
-module.exports = normalizeCjs;
-
-var reduceLeadingDots = path.reduceLeadingDots;
-
-function normalizeCjs (name, refererName, refererUrl) {
-	return reduceLeadingDots(String(name), refererName || '');
-}
-
-});
-
-
 ;define('rave/pipeline/fetchAsText', ['require', 'exports', 'module', 'rave/lib/fetchText'], function (require, exports, module, $cram_r0, define) {module.exports = fetchAsText;
 
 var fetchText = $cram_r0;
@@ -2960,6 +2939,19 @@ function fetchAsText (load) {
 		fetchText(load.address, resolve, reject);
 	});
 
+}
+
+});
+
+
+;define('rave/pipeline/normalizeCjs', ['require', 'exports', 'module', 'rave/lib/path'], function (require, exports, module, $cram_r0, define) {var path = $cram_r0;
+
+module.exports = normalizeCjs;
+
+var reduceLeadingDots = path.reduceLeadingDots;
+
+function normalizeCjs (name, refererName, refererUrl) {
+	return reduceLeadingDots(String(name), refererName || '');
 }
 
 });

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -6,6 +6,8 @@ var locateAsIs = require('rave/pipeline/locateAsIs');
 var fetchAsText = require('rave/pipeline/fetchAsText');
 var translateAsIs = require('rave/pipeline/translateAsIs');
 var instantiateNode = require('rave/pipeline/instantiateNode');
+var nodeFactory = require('rave/lib/debug/nodeFactory');
+var nodeEval = require('rave/lib/debug/nodeEval');
 var instantiateJson = require('rave/pipeline/instantiateJson');
 var path = require('rave/lib/path');
 var beget = require('rave/lib/beget');
@@ -36,7 +38,7 @@ function baseHooks (context) {
 		package: 'rave',
 		hooks: {
 			locate: locateRaveWithContext(context),
-			instantiate: instantiateNode
+			instantiate: instantiateNode(nodeFactory(nodeEval))
 		}
 	};
 

--- a/src/rave.js
+++ b/src/rave.js
@@ -1,15 +1,14 @@
 /** @license MIT License (c) copyright 2014 original authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
-var rave, document, defaultMain, debugMain, hooksName,
+var rave, doc, defaultMain, hooksName,
 	context, loader, define;
 
 rave = exports || {};
 
-document = global.document;
+doc = global.document;
 
-defaultMain = 'rave/auto';
-debugMain = 'rave/debug';
+defaultMain = 'rave/debug';
 hooksName = 'rave/src/hooks';
 
 // export testable functions
@@ -22,11 +21,11 @@ rave.simpleDefine = simpleDefine;
 // initialize
 rave.scriptUrl = getCurrentScript();
 rave.scriptPath = getPathFromUrl(rave.scriptUrl);
-rave.baseUrl = document
+rave.baseUrl = doc
 	? getPathFromUrl(window.location.origin + window.location.pathname)
 	: __dirname;
 
-context = (document ? mergeBrowserOptions : mergeNodeOptions)({
+context = (doc ? mergeBrowserOptions : mergeNodeOptions)({
 	debug: true,
 	raveMain: defaultMain,
 	raveScript: rave.scriptUrl,
@@ -41,11 +40,6 @@ define.amd = {};
 function boot (context) {
 	var main = context.raveMain;
 	try {
-		// check if we should load debugMain instead
-		if (context.debug || context.raveDebug) {
-			// don't override main if user changed it with <html> attr
-			if (context.raveMain === defaultMain) context.raveMain = debugMain;
-		}
 		// apply hooks overrides to loader
 		var hooks = fromLoader(loader.get(hooksName));
 		// extend loader
@@ -71,7 +65,7 @@ function getCurrentScript () {
 	var stack, matches;
 
 	// HTML5 way
-	if (document && document.currentScript) return document.currentScript.src;
+	if (doc && doc.currentScript) return doc.currentScript.src;
 
 	// From https://gist.github.com/cphoover/6228063
 	// (Note: Ben Alman's shortcut doesn't work everywhere.)
@@ -90,14 +84,12 @@ function getPathFromUrl (url) {
 }
 
 function mergeBrowserOptions (context) {
-	var el = document.documentElement, i, attr, prop;
-	for (i = 0; i < el.attributes.length; i++) {
-		attr = el.attributes[i];
-		prop = attr.name.slice(5).replace(/(?:data)?-(.)/g, camelize);
-		if (prop) context[prop] = attr.value || true;
+	var el = doc.documentElement, i, attr, prop;
+	var meta = el.getAttribute('data-rave-meta');
+	if (meta) {
+		context.raveMeta = meta;
 	}
 	return context;
-	function camelize (m, l) { return l.toUpperCase();}
 }
 
 function mergeNodeOptions (context) {

--- a/src/rave.js
+++ b/src/rave.js
@@ -27,6 +27,7 @@ rave.baseUrl = document
 	: __dirname;
 
 context = (document ? mergeBrowserOptions : mergeNodeOptions)({
+	debug: true,
 	raveMain: defaultMain,
 	raveScript: rave.scriptUrl,
 	baseUrl: rave.baseUrl,

--- a/test/lib/amd/captureDefines.js
+++ b/test/lib/amd/captureDefines.js
@@ -4,6 +4,7 @@ var refute = buster.refute;
 var fail = buster.assertions.fail;
 
 var captureDefines = require('../../../lib/amd/captureDefines');
+var amdEval = require('../../../lib/amd/eval');
 
 var nameOptions = { '': 1, 'name': 1 };
 var depCounts = { 'none': 1, 0: 1, 1: 1, 3: 1 };
@@ -20,8 +21,12 @@ buster.testCase('rave/lib/amd/captureDefines', {
 						? null
 						: depsList.slice(0, depCount);
 					var def = generateDefine(name, deps, factory);
+					var load = {
+						name: 'module_under_test',
+						source: def
+					};
 					refute.exception(function () {
-						captureDefines(def);
+						captureDefines(amdEval)(load);
 					});
 				}
 			}
@@ -29,27 +34,28 @@ buster.testCase('rave/lib/amd/captureDefines', {
 	},
 
 	'should always return a factory': function () {
-		var def;
-		def = generateDefine(null, null, '{}');
-		assert.isFunction(captureDefines(def).anon.factory, 'factory is object');
-		def = generateDefine(null, null, '"foo"');
-		assert.isFunction(captureDefines(def).anon.factory, 'factory is string');
-		def = generateDefine(null, null, '/foo/g');
-		assert.isFunction(captureDefines(def).anon.factory, 'factory is RegExp');
+		var load;
+		load = { name: 'module_under_test' };
+		load.source = generateDefine(null, null, '{}');
+		assert.isFunction(captureDefines(amdEval)(load).anon.factory, 'factory is object');
+		load.source = generateDefine(null, null, '"foo"');
+		assert.isFunction(captureDefines(amdEval)(load).anon.factory, 'factory is string');
+		load.source = generateDefine(null, null, '/foo/g');
+		assert.isFunction(captureDefines(amdEval)(load).anon.factory, 'factory is RegExp');
 	},
 
 	'should detect a named module': function () {
-		var def;
-		def = generateDefine('foo', null, '{}');
-		assert.equals('foo', captureDefines(def).named[0].name);
+		var load = { name: 'tst' };
+		load.source = generateDefine('foo', null, '{}');
+		assert.equals('foo', captureDefines(amdEval)(load).named[0].name);
 	},
 
 	'should detect dependencies': function () {
-		var def;
-		def = generateDefine('foo', ['bar', 'baz'], '{}');
-		assert.equals(['bar', 'baz'], captureDefines(def).named[0].depsList, 'named module');
-		def = generateDefine(null, ['bar', 'baz'], '{}');
-		assert.equals(['bar', 'baz'], captureDefines(def).anon.depsList, 'anonymous module');
+		var load = { name: 'test' };
+		load.source = generateDefine('foo', ['bar', 'baz'], '{}');
+		assert.equals(['bar', 'baz'], captureDefines(amdEval)(load).named[0].depsList, 'named module');
+		load.source = generateDefine(null, ['bar', 'baz'], '{}');
+		assert.equals(['bar', 'baz'], captureDefines(amdEval)(load).anon.depsList, 'anonymous module');
 	}
 
 });


### PR DESCRIPTION
We've been having a hell of a time debugging rave-based projects.  The problems have been primarily due to bugs in browsers and browser debuggers when using the most efficient method for evaluating source code: `new Function(source)`.  There are few tickets for these bugs, but they have been neglected, some for years.  I implemented some alternative versions of code evaluation functions using script injection and these are much, much more debuggable.  Script injection isn't nearly as efficient, so we don't want to use this in production (ignoring CSP environments for now).  

Obviously, decent debugging should be the default regardless of CPU, memory, and code bulk during development.

This got me thinking.  After a quick convo with @briancavalier, I'm thinking that rave should be in "debug mode" by default.  Debugging should be "off" only when building for production or when explicitly specified by the developer.  
- [X] implement code eval modules that use script injection
- [x] override production code eval modules with debuggable versions at run time when in "debug mode"
- [x] set rave's default mode to "debug mode"
- [x] load debug modules instead of production modules in rave/rave and rave/auto
- [x] remove code to sniff data-debug or other data-\* attrs (leaving only data-rave-meta to find the correct metadata file(s))
- [x] add the rave global object (the "REPL") automatically. don't force the dev to type `rave()`
- [x] only load addSourceUrl module when in debug mode

I decided to defer these until later:
- [ ] implement rave metadata-based config (which will allow devs to set `"debug":false`)
  - [ ] configure rave using a "config" property under the "rave" property in the app's package.json or bower.json
- [ ] implement per-package config to allow devs to set debug levels and other options per package
