### PR TITLE
Even if there is not the JSON, the rave.missing does work.

### DIFF
--- a/rave.js
+++ b/rave.js
@@ -3944,6 +3944,10 @@ function applyOverrides (context, data) {
 		_applyOverrides(false, context.overrides, data);
 		_applyOverrides(true, context.missing, data);
 	}
+	else if (context.name in context.missing){
+		data = Object.create(context.missing[context.name]);
+		_applyOverrides(false, context.overrides, data);
+	}
 	return data;
 }
 


### PR DESCRIPTION
Hi there,

Thank you for providing RaveJS.

If there is not both the bower.json and package.json, rave.missing did not work.
Please consider the merge.

Thanks,
atomita
